### PR TITLE
Fix black screen and triple jump bugs

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -62,21 +62,21 @@ window/stretch/aspect="keep"
 
 left={
 "deadzone": 0.5,
-"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":16777231,"unicode":0,"echo":false,"script":null)
-, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":0,"unicode":0,"echo":false,"script":null)
+"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":16777231,"physical_scancode":0,"unicode":0,"echo":false,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":0,"physical_scancode":0,"unicode":0,"echo":false,"script":null)
  ]
 }
 right={
 "deadzone": 0.5,
-"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":16777233,"unicode":0,"echo":false,"script":null)
-, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":0,"unicode":0,"echo":false,"script":null)
+"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":16777233,"physical_scancode":0,"unicode":0,"echo":false,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":0,"physical_scancode":0,"unicode":0,"echo":false,"script":null)
  ]
 }
 jump={
 "deadzone": 0.5,
-"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":32,"unicode":0,"echo":false,"script":null)
-, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":0,"unicode":0,"echo":false,"script":null)
-, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":0,"unicode":0,"echo":false,"script":null)
+"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":32,"physical_scancode":0,"unicode":0,"echo":false,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":0,"physical_scancode":0,"unicode":0,"echo":false,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":0,"physical_scancode":0,"unicode":0,"echo":false,"script":null)
  ]
 }
 down={

--- a/scenes/GassyRandal.tscn
+++ b/scenes/GassyRandal.tscn
@@ -44,7 +44,6 @@ script = ExtResource( 2 )
 
 [node name="AnimatedSprite" type="AnimatedSprite" parent="."]
 frames = SubResource( 6 )
-frame = 3
 speed_scale = 1.25
 playing = true
 

--- a/scenes/Player.tscn
+++ b/scenes/Player.tscn
@@ -39,9 +39,6 @@ region = Rect2( 96, 32, 32, 32 )
 atlas = ExtResource( 2 )
 region = Rect2( 128, 32, 32, 32 )
 
-[sub_resource type="AtlasTexture" id=9]
-atlas = ExtResource( 2 )
-region = Rect2( 160, 32, 32, 32 )
 [sub_resource type="SpriteFrames" id=10]
 animations = [ {
 "frames": [ SubResource( 2 ) ],
@@ -49,7 +46,6 @@ animations = [ {
 "name": "idle",
 "speed": 5.0
 }, {
-
 "frames": [ SubResource( 9 ) ],
 "loop": true,
 "name": "jump",

--- a/scripts/Main.gd
+++ b/scripts/Main.gd
@@ -11,14 +11,14 @@ func _ready() -> void:
   VisualServer.set_default_clear_color(Color(0,0,0,1.0))
 
 func _hook_portals() -> void:
-  for portal in get_tree().get_nodes_in_group(ENDPORTALS_GROUP):
-    # Avoid objects that should not be in the group.
-    if not portal is EndPortal:
-      continue
-    # Avoid connecting the same object several times.
-    if portal.is_connected("body_entered", self, "_on_endportal_body_entered"):
-      continue
-    portal.connect("body_entered", self, "_on_endportal_body_entered", [ portal.next_level, portal ])
+	for portal in get_tree().get_nodes_in_group(ENDPORTALS_GROUP):
+	# Avoid objects that should not be in the group.
+		if not portal is EndPortal:
+		  continue
+		# Avoid connecting the same object several times.
+		if portal.is_connected("body_entered", self, "_on_endportal_body_entered"):
+		  continue
+		portal.connect("body_entered", self, "_on_endportal_body_entered", [ portal.next_level, portal ])
 
 
 func _on_endportal_body_entered(_body : Node2D, next_level : PackedScene, portal) -> void:
@@ -30,20 +30,20 @@ func _on_endportal_body_entered(_body : Node2D, next_level : PackedScene, portal
 
 
 func _finish_level(next_level : PackedScene = null) -> void:
-  if next_level:
-    # Create the new level, insert it into the tree and remove the old one.
-    var new_level : TileMap = next_level.instance()
-    add_child_below_node(level, new_level)
-    remove_child(level)
-    level = new_level
+	if next_level:
+		# Create the new level, insert it into the tree and remove the old one.
+		var new_level : TileMap = next_level.instance()
+		add_child_below_node(level, new_level)
+		remove_child(level)
+		level = new_level
 
-    # Do not forget to hook the new portals
-    _hook_portals()
-    
-    #Removing instructions 
-    $UI/UI/RichTextLabel.visible = false;
+		# Do not forget to hook the new portals
+		_hook_portals()
+		
+		#Removing instructions 
+		$UI/UI/RichTextLabel.visible = false;
 
-    # We need to flash the player out and in the tree to avoid physics errors.
-    remove_child(player)
-    add_child_below_node(level, player)
-    EventBus.emit_signal("level_started", {})
+		# We need to flash the player out and in the tree to avoid physics errors.
+		remove_child(player)
+		add_child_below_node(level, player)
+		EventBus.emit_signal("level_started", {})

--- a/scripts/Player.gd
+++ b/scripts/Player.gd
@@ -13,6 +13,7 @@ const JUMP_BUFFER_TIME = 0.05
 
 var coyote_timer = COYOTE_TIME # used to give a bit of extra-time to jump after leaving the ground
 var jump_buffer_timer = 0 # gives a bit of buffer to hit the jump button before landing
+var jump_counter = 0 # used to prevent triple jumps
 var motion = Vector2()
 var gravity_multiplier = 1 # used for jump height variability
 var double_jump = true
@@ -51,7 +52,7 @@ func _physics_process(delta : float) -> void:
 	if Input.is_action_just_pressed("jump"):
 		if coyote_timer > 0:
 			jump()
-		elif double_jump:
+		elif double_jump and jump_counter < 1:
 			jump()
 			double_jump = false
 		else:
@@ -66,6 +67,8 @@ func _physics_process(delta : float) -> void:
 			jump()
 		elif Input.is_action_just_pressed("down"):
 			crouch()
+		if jump_counter != 0:
+			jump_counter = 0
 	else:
 		coyote_timer -= delta
 		# while we're holding the jump button we should jump higher
@@ -87,6 +90,7 @@ func crouch():
 
 func jump():
 	jump_buffer_timer = 0
+	jump_counter += 1
 	squash(0.075);
 	yield(tween, "tween_all_completed")
 	stretch(0.15);

--- a/sprites/Coin_Gems/Coin/Hitbox.gd
+++ b/sprites/Coin_Gems/Coin/Hitbox.gd
@@ -10,6 +10,6 @@ func _on_body_entered(body):
   EventBus.emit_signal("coin_collected", { "value": 1, "type": "gold" })
   audio_player.play()
   animation.play("Collect")
-  monitoring = false
+  set_deferred("monitoring",false)
   yield(animation, "animation_finished")
   queue_free()

--- a/sprites/bg-tile.png.import
+++ b/sprites/bg-tile.png.import
@@ -28,6 +28,7 @@ process/fix_alpha_border=true
 process/premult_alpha=false
 process/HDR_as_SRGB=false
 process/invert_color=false
+process/normal_map_invert_y=false
 stream=false
 size_limit=0
 detect_3d=true

--- a/sprites/gassy-randal.png.import
+++ b/sprites/gassy-randal.png.import
@@ -28,6 +28,7 @@ process/fix_alpha_border=true
 process/premult_alpha=false
 process/HDR_as_SRGB=false
 process/invert_color=false
+process/normal_map_invert_y=false
 stream=false
 size_limit=0
 detect_3d=true

--- a/sprites/icon.png.import
+++ b/sprites/icon.png.import
@@ -28,6 +28,7 @@ process/fix_alpha_border=true
 process/premult_alpha=false
 process/HDR_as_SRGB=false
 process/invert_color=false
+process/normal_map_invert_y=false
 stream=false
 size_limit=0
 detect_3d=true

--- a/sprites/mario-enter-portal.png.import
+++ b/sprites/mario-enter-portal.png.import
@@ -28,6 +28,7 @@ process/fix_alpha_border=true
 process/premult_alpha=false
 process/HDR_as_SRGB=false
 process/invert_color=false
+process/normal_map_invert_y=false
 stream=false
 size_limit=0
 detect_3d=true

--- a/sprites/mario.png.import
+++ b/sprites/mario.png.import
@@ -28,6 +28,7 @@ process/fix_alpha_border=true
 process/premult_alpha=false
 process/HDR_as_SRGB=false
 process/invert_color=false
+process/normal_map_invert_y=false
 stream=false
 size_limit=0
 detect_3d=false

--- a/sprites/portal.png.import
+++ b/sprites/portal.png.import
@@ -28,6 +28,7 @@ process/fix_alpha_border=true
 process/premult_alpha=false
 process/HDR_as_SRGB=false
 process/invert_color=false
+process/normal_map_invert_y=false
 stream=false
 size_limit=0
 detect_3d=false

--- a/sprites/tile.png.import
+++ b/sprites/tile.png.import
@@ -28,6 +28,7 @@ process/fix_alpha_border=true
 process/premult_alpha=false
 process/HDR_as_SRGB=false
 process/invert_color=false
+process/normal_map_invert_y=false
 stream=false
 size_limit=0
 detect_3d=true


### PR DESCRIPTION
This merge request includes 3 commits, the first of which fixes some mixed indentation in Main.gd (otherwise can't run the script on Windows 10, not sure about other OSs).

The second commit adds a jump counter and checks if the player already has double jumped to prevent triple jumps (it was possible to do with good timing, can replicate by running left & right while spamming jump).

The third commit fixes a rare bug that would sometimes cause the coin hitbox script to fail during scene transitions and cause a black screen.