### PR TITLE
Lower the trail source when crouching

### DIFF
--- a/scripts/Player.gd
+++ b/scripts/Player.gd
@@ -26,9 +26,8 @@ var grounded = false
 var anticipating_jump = false # the small window of time before the player jumps
 
 onready var sprite = $Sprite
-
 onready var tween = $Tween
-
+onready var trail = $Trail
 onready var run_particles = $RunParticles
 
 onready var original_scale = sprite.scale;
@@ -132,8 +131,6 @@ func try_slip(angle: float):
 	position[axis] = original_v
 	return false
 
-
-
 func _input(event :InputEvent):
 	# Remove one coin and spawn a projectile
 	# Continus shooting after 0 coins
@@ -189,7 +186,13 @@ func squash(time=0.1, _returnDelay=0, squash_modifier=1.0):
 		lerp(original_scale, squash_scale, squash_modifier),
 		time, Tween.TRANS_BACK, Tween.EASE_OUT
 	)
-	tween.start();
+	tween.interpolate_property(
+		trail, "height",
+		trail.height,
+		20 * squash_modifier,
+		time, Tween.TRANS_BACK, Tween.EASE_OUT
+	)
+	tween.start()
 
 func stretch(time=0.2, _returnDelay=0, squash_modifier=1.0, stretch_modifier=1.0):
 	tween.remove_all()
@@ -212,6 +215,12 @@ func unsquash(time=0.1, _returnDelay=0, squash_modifier=1.0):
 		sprite, "scale",
 		lerp(original_scale, squash_scale, squash_modifier),
 		original_scale,
+		time, Tween.TRANS_BACK, Tween.EASE_OUT
+	)
+	tween.interpolate_property(
+		trail, "height",
+		trail.height,
+		0,
 		time, Tween.TRANS_BACK, Tween.EASE_OUT
 	)
 	tween.start();

--- a/scripts/Trail.gd
+++ b/scripts/Trail.gd
@@ -2,13 +2,14 @@ extends Line2D
 
 export(int) var trail_length = 5;
 var positions = []
+var height = 0.0
 
 onready var parent = get_parent()
 
 func _process(_delta):
-	self.global_position = Vector2(0.0, 0.0)
-	
+	global_position = Vector2(0, 0)
+
 	while len(positions) > trail_length:
 		positions.pop_front()
-	positions.push_back(parent.global_position)
+	positions.push_back(parent.global_position + Vector2(0, height))
 	points = PoolVector2Array(positions)


### PR DESCRIPTION
When crouching the trail appeared above the player, now it correctly follows the player motion.

Preview:

![sneaking-preview](https://user-images.githubusercontent.com/28286961/162626945-3a2eda5e-7761-44d1-bfe6-38e9bb09fba7.gif)

