### PR TITLE
Add Godot auto-formatter

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -27,7 +27,6 @@ jobs:
         with:
           commit_message: Auto-Format GDScript
           file_pattern: "**/*.gd"
-          commit_user_name: Grumpy Godot Auto-Formatter
 
   build_game:
     name: Build Game

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -14,9 +14,25 @@ on:
       - '**.md'
 
 jobs:
-  build_game:
+  format_code:
     runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v3
+        with: 
+          python-version: 3.x
+      - run: pip3 install 'gdtoolkit==3.*'
+      - run: gdformat **/*.gd
+      - uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: Auto-Format GDScript
+          file_pattern: "**/*.gd"
+          commit_user_name: Grumpy Godot Auto-Formatter
+
+  build_game:
     name: Build Game
+    needs: format_code
+    runs-on: ubuntu-latest
     steps:
       - name: checkout latest code
         uses: actions/checkout@v2.3.1

--- a/autoload/EventBus.gd
+++ b/autoload/EventBus.gd
@@ -12,6 +12,6 @@ signal game_paused(data)
 
 ## settings signals
 # toggles crt filter - emitted by PauseMenu.gd and connected to Main.gd
-signal crt_filter_toggle (data)
+signal crt_filter_toggle(data)
 # self-explanatory - emitted by PauseMenu.gd and connected to Main.gd
-signal volume_changed (data)
+signal volume_changed(data)

--- a/autoload/Settings.gd
+++ b/autoload/Settings.gd
@@ -3,11 +3,11 @@ extends Node
 const CameraLeanAmount = preload("res://scripts/CameraLeanAmount.gd")
 
 # graphics settings
-var camera_lean : int = CameraLeanAmount.MAX;
-var screen_shake : bool = true;
-var crt_filter : bool = true;
+var camera_lean: int = CameraLeanAmount.MAX
+var screen_shake: bool = true
+var crt_filter: bool = true
 
 # sfx settings
-var volume_game : int = 10;
-var volume_music : int = 10;
-var volume_sfx : int = 10;
+var volume_game: int = 10
+var volume_music: int = 10
+var volume_sfx: int = 10

--- a/scenes/Credits.gd
+++ b/scenes/Credits.gd
@@ -5,8 +5,9 @@ const SPEED = 50.0
 onready var scroll_container = $ScrollContainer
 onready var vscroll = scroll_container.get_v_scrollbar()
 
+
 func _process(delta):
 	vscroll.value += delta * SPEED
-	
+
 	if vscroll.value >= vscroll.max_value - scroll_container.rect_size.y:
 		get_tree().change_scene("res://scenes/Main.tscn")

--- a/scripts/Achievement.gd
+++ b/scripts/Achievement.gd
@@ -3,7 +3,6 @@ class_name Achievement
 
 enum Type { COINS }
 
-export (Type) var type
-export (String) var ID
-export (String) var description
-
+export(Type) var type
+export(String) var ID
+export(String) var description

--- a/scripts/Bub.gd
+++ b/scripts/Bub.gd
@@ -1,9 +1,9 @@
 # Implements the Bub enemy type.
-# This enemy walks forward until it bumps into a wall at which point it 
-# reverses direction and continues. Affected by gravity and will fall 
+# This enemy walks forward until it bumps into a wall at which point it
+# reverses direction and continues. Affected by gravity and will fall
 # down stairs and into pits.
 #
-# Bub is a friendly sort and doesn't hurt or damage the player in any 
+# Bub is a friendly sort and doesn't hurt or damage the player in any
 # way. He'll even give the player a lift if he cares to jump on!
 #
 # Bub wishes all enemies were as nice as him.
@@ -40,9 +40,10 @@ onready var _muzzle := $GunAnchor/Sprite/Muzzle
 onready var sprite := $Sprite
 onready var tween := $Tween
 
-onready var original_scale = sprite.scale;
-onready var squash_scale = Vector2(original_scale.x*1.4, original_scale.y*0.4)
+onready var original_scale = sprite.scale
+onready var squash_scale = Vector2(original_scale.x * 1.4, original_scale.y * 0.4)
 onready var stretch_scale = Vector2(original_scale.x * 0.4, original_scale.y * 1.4)
+
 
 func _ready():
 	start_walking()
@@ -54,7 +55,7 @@ func _ready():
 func ai(_delta: float):
 	_sprite.flip_h = direction > 0
 	_gun_anchor.scale.x = -sign(direction)
-	
+
 	if is_dying():
 		return
 
@@ -72,7 +73,7 @@ func ai(_delta: float):
 func move(_delta: float):
 	if is_dying():
 		return
-	
+
 	_motion.y += GRAVITY
 
 	if _motion.y > MAXFALLSPEED:
@@ -85,7 +86,7 @@ func move(_delta: float):
 		_motion.x = 0
 
 	_motion = move_and_slide(_motion, UP)
-	
+
 	_ray_walking.cast_to.x = direction * RAY_CAST_WALKING_DISTANCE
 	_ray_walking.force_raycast_update()
 	if _ray_walking.is_colliding():
@@ -99,14 +100,15 @@ func disable_collision():
 	$KillTrigger.queue_free()
 
 
-# Disables collision, plays the sprite death animation and the 
-# death animation from the animation player. The function then yields 
+# Disables collision, plays the sprite death animation and the
+# death animation from the animation player. The function then yields
 # until the animations are finished.
 func _handle_dying(_killer):
 	disable_collision()
 	_animation_player.play("die")
-	$SquishParticles.emitting=true
+	$SquishParticles.emitting = true
 	yield(_animation_player, "animation_finished")
+
 
 # called from the animation controller
 func fire_bullet():
@@ -118,28 +120,43 @@ func fire_bullet():
 	_shooting_cooldown = MAX_SHOOTING_COOLDOWN
 	start_walking()
 
+
 func start_walking():
 	_moving = true
 	_animation_player.play("move")
+
 
 func _on_KillTrigger_body_entered(body):
 	if not body is Player:
 		return
 	var player = body as Player
 	player.bounce(BOUNCE_STRENGTH)
-	squash(0.075);
+	squash(0.075)
 	yield(tween, "tween_all_completed")
-	stretch(0.15);
+	stretch(0.15)
 
 
 # This isn't the best place to put these tweening functions and also copied from Player
 # Couldn't this be an animation?
-func squash(time=0.1, returnDelay=0):
-	tween.interpolate_property(sprite, "scale", original_scale, squash_scale, time, Tween.TRANS_BACK, Tween.EASE_OUT)
-	tween.start();
-
-func stretch(time=0.2, returnDelay=0):
-	tween.interpolate_property(sprite, "scale", squash_scale, stretch_scale, time, Tween.TRANS_BACK, Tween.EASE_OUT)
-	tween.interpolate_property(sprite, "scale", stretch_scale, original_scale, time, Tween.TRANS_BACK, Tween.EASE_OUT, time/2)
+func squash(time = 0.1, returnDelay = 0):
+	tween.interpolate_property(
+		sprite, "scale", original_scale, squash_scale, time, Tween.TRANS_BACK, Tween.EASE_OUT
+	)
 	tween.start()
 
+
+func stretch(time = 0.2, returnDelay = 0):
+	tween.interpolate_property(
+		sprite, "scale", squash_scale, stretch_scale, time, Tween.TRANS_BACK, Tween.EASE_OUT
+	)
+	tween.interpolate_property(
+		sprite,
+		"scale",
+		stretch_scale,
+		original_scale,
+		time,
+		Tween.TRANS_BACK,
+		Tween.EASE_OUT,
+		time / 2
+	)
+	tween.start()

--- a/scripts/Bullet.gd
+++ b/scripts/Bullet.gd
@@ -2,11 +2,13 @@ extends KinematicBody2D
 
 const SPEED = 4
 
+
 func _ready():
-	pass 
+	pass
+
 
 func _physics_process(delta):
 	var collision = move_and_collide(transform.x * SPEED)
 	if collision:
-	# add effect here
+		# add effect here
 		queue_free()

--- a/scripts/Camera.gd
+++ b/scripts/Camera.gd
@@ -2,42 +2,46 @@ extends Camera2D
 class_name ShakingCamera
 onready var _screen_shake: ScreenShake = $ScreenShake
 
-const CameraLeanAmount = preload("res://scripts/CameraLeanAmount.gd");
+const CameraLeanAmount = preload("res://scripts/CameraLeanAmount.gd")
+
 
 func _ready():
-  EventBus.connect("enemy_killed", self, "trigger_small_shake")
-  position = get_viewport_rect().size / 2
+	EventBus.connect("enemy_killed", self, "trigger_small_shake")
+	position = get_viewport_rect().size / 2
+
 
 func _process(_delta):
 	if Input.is_action_pressed("right"):
-		var lean_amount : float = 0;
+		var lean_amount: float = 0
 		if CameraLeanAmount.MAX == Settings.camera_lean:
-			lean_amount=PI/64;
+			lean_amount = PI / 64
 		elif CameraLeanAmount.MIN == Settings.camera_lean:
-			lean_amount=PI/128;
-		lean(-lean_amount);
+			lean_amount = PI / 128
+		lean(-lean_amount)
 	elif Input.is_action_pressed("left"):
-		var lean_amount : float = 0;
+		var lean_amount: float = 0
 		if CameraLeanAmount.MAX == Settings.camera_lean:
-			lean_amount=PI/64;
+			lean_amount = PI / 64
 		elif CameraLeanAmount.MIN == Settings.camera_lean:
-			lean_amount=PI/128;
-		lean(lean_amount);
+			lean_amount = PI / 128
+		lean(lean_amount)
 	else:
-		lean(0, 0.1);
-	
+		lean(0, 0.1)
+
+
 func lean(radians, speed := 0.05) -> void:
-  rotation = lerp(rotation, radians, speed)
-  zoom.x = lerp(zoom.x, 1 + radians / 2.0, speed * 2)
-  zoom.y = lerp(zoom.y, 1 - radians / 2.0, speed * 2)
+	rotation = lerp(rotation, radians, speed)
+	zoom.x = lerp(zoom.x, 1 + radians / 2.0, speed * 2)
+	zoom.y = lerp(zoom.y, 1 - radians / 2.0, speed * 2)
+
 
 func trigger_small_shake() -> void:
-  _screen_shake.start(.1, 8, 10, 7)
+	_screen_shake.start(.1, 8, 10, 7)
 
 
 func trigger_medium_shake() -> void:
-  _screen_shake.start(.1, 15, 20, 5)
+	_screen_shake.start(.1, 15, 20, 5)
 
 
 func trigger_large_shake() -> void:
-  _screen_shake.start(.1, 20, 50, 10)
+	_screen_shake.start(.1, 20, 50, 10)

--- a/scripts/CameraLeanAmount.gd
+++ b/scripts/CameraLeanAmount.gd
@@ -1,4 +1,4 @@
 extends Node
 class_name CameraLeanAmount
 
-enum {OFF,MIN,MAX}
+enum { OFF, MIN, MAX }

--- a/scripts/CoinProjectile.gd
+++ b/scripts/CoinProjectile.gd
@@ -1,7 +1,9 @@
 extends PlayerProjectile
 
-func _handle_start(_dir :Vector2):
+
+func _handle_start(_dir: Vector2):
 	$Shoot.play()
+
 
 func _handle_destruction():
 	$Hit.play()

--- a/scripts/CoinsAchievement.gd
+++ b/scripts/CoinsAchievement.gd
@@ -1,5 +1,5 @@
 extends Achievement
 class_name CoinsAchievement
 
-export (int) var levelNumber
-export (int) var coinsRequired
+export(int) var levelNumber
+export(int) var coinsRequired

--- a/scripts/EndPortal.gd
+++ b/scripts/EndPortal.gd
@@ -4,18 +4,19 @@ extends Area2D
 # You can use this to chain towards another level.
 # When the player enters the Area2D, the current level will be unloaded and the
 #  new one loaded in its place.
-export var next_level : PackedScene
+export var next_level: PackedScene
 
-onready var mario : AnimatedSprite = $Mario
+onready var mario: AnimatedSprite = $Mario
 
 
 func _ready():
-  $Sprite.play()
+	$Sprite.play()
+
 
 func on_portal_enter():
-  mario.visible = true
-  mario.frame = 0
-  mario.play()
-  $PortalSFX.play()
-  EventBus.emit_signal("level_completed", { })
-  return mario
+	mario.visible = true
+	mario.frame = 0
+	mario.play()
+	$PortalSFX.play()
+	EventBus.emit_signal("level_completed", {})
+	return mario

--- a/scripts/Enemy.gd
+++ b/scripts/Enemy.gd
@@ -2,17 +2,16 @@
 extends KinematicBody2D
 class_name Enemy
 
-
 # Emitted when the enemy is moving into a dead state.
 signal dying(killer)
 # Emitted when the enemy has actually shuffled off this mortal coil.
 signal dead(killer)
 
-# Determines if the enemy is alive or not. AI and movement will only 
+# Determines if the enemy is alive or not. AI and movement will only
 # be processed if alive is true.
 export(bool) var alive = true
 
-# A midpoint between being alive and not. The enemy will die eventually, 
+# A midpoint between being alive and not. The enemy will die eventually,
 # but will wait for things like animations to finish first.
 var _dying = false
 
@@ -49,17 +48,17 @@ func kill(killer):
 	queue_free()
 
 
-# Override this function to implement enemy-specific death animations, 
+# Override this function to implement enemy-specific death animations,
 # sounds, effects, etc.
 #
-# Prepares the enemy for leaving their physical form. Trigger any death 
-# animations or sounds here. Supports yielding until animations, etc. are 
+# Prepares the enemy for leaving their physical form. Trigger any death
+# animations or sounds here. Supports yielding until animations, etc. are
 # completed. Once this function returns the enemy will be removed.
 func _handle_dying(_killer):
 	pass
 
 
-# Helper function to disable collision. Useful if you want the enemy to 
+# Helper function to disable collision. Useful if you want the enemy to
 # fall through the world, for instance.
 func disable_collision():
 	_collision.set_deferred("disabled", true)
@@ -67,10 +66,10 @@ func disable_collision():
 
 # Override this function to implement enemy-specific AI.
 #
-# The ai function is called every _process tick and is used to implement 
-# specific AI traits for enemies such as deciding on movement or player 
-# interaction. Note that decisions about movement can happen here, but 
-# should only be implemented in the move() function which happens during 
+# The ai function is called every _process tick and is used to implement
+# specific AI traits for enemies such as deciding on movement or player
+# interaction. Note that decisions about movement can happen here, but
+# should only be implemented in the move() function which happens during
 # the physics step.
 func ai(_delta: float):
 	pass
@@ -86,4 +85,3 @@ func move(_delta: float):
 func _on_KillTrigger_body_entered(body):
 	if body is Player:
 		kill(self)
-

--- a/scripts/GassyRandal.gd
+++ b/scripts/GassyRandal.gd
@@ -5,33 +5,39 @@ extends KinematicBody2D
 
 var rando = RandomNumberGenerator.new()
 
+
 #blink
 func _on_BlinkTimer_timeout() -> void:
-	$EyeSprite.visible=false
+	$EyeSprite.visible = false
 	$OpenTimer.start()
 	pass
 
+
 #open eyes back up
 func _on_OpenTimer_timeout():
-	$EyeSprite.visible=true
+	$EyeSprite.visible = true
 	$BlinkTimer.start()
-	pass 
+	pass
+
 
 func _process(delta: float):
 	randalRotate()
 	randalVibe()
 
+
 func randalRotate():
-	$RandalCloud.rotation_degrees+=0.5
-	$BigRandalCloud.rotation_degrees-=0.1
+	$RandalCloud.rotation_degrees += 0.5
+	$BigRandalCloud.rotation_degrees -= 0.1
 	pass
+
 
 func randalVibe():
 	rando.randomize()
-	
-	position.x+=rando.randf_range(-1,1)
-	position.y+=rando.randf_range(-1,1)
+
+	position.x += rando.randf_range(-1, 1)
+	position.y += rando.randf_range(-1, 1)
 	pass
 
+
 func _ready():
-	pass # Replace with function body.
+	pass  # Replace with function body.

--- a/scripts/Main.gd
+++ b/scripts/Main.gd
@@ -1,25 +1,27 @@
 extends Viewport
 
-const SPAWNPOINTS_GROUP : String = "SpawnPoints"
-const ENDPORTALS_GROUP : String = "EndPortals"
-const COINS_GROUP : String = "Coins"
+const SPAWNPOINTS_GROUP: String = "SpawnPoints"
+const ENDPORTALS_GROUP: String = "EndPortals"
+const COINS_GROUP: String = "Coins"
 
-onready var hub : TileMap = $TileMap
-onready var level : TileMap = $TileMap
-onready var player : Player = $Player
+onready var hub: TileMap = $TileMap
+onready var level: TileMap = $TileMap
+onready var player: Player = $Player
 
-onready var container : ViewportContainer = get_parent()
+onready var container: ViewportContainer = get_parent()
 onready var crt_shader = preload("res://shaders/CRT.gdshader")
 
 var completionSound = preload("res://sfx/portal.wav")
 var coinSound = preload("res://sfx/coin.wav")
 
+
 func _ready() -> void:
 	EventBus.connect("build_block", self, "_on_build")
 	_hook_portals()
-	EventBus.connect("crt_filter_toggle",self,"_on_crt_toggle")
-	EventBus.connect("volume_changed",self,"_on_volume_change")
+	EventBus.connect("crt_filter_toggle", self, "_on_crt_toggle")
+	EventBus.connect("volume_changed", self, "_on_volume_change")
 	VisualServer.set_default_clear_color(Color.black)
+
 
 func _hook_portals() -> void:
 	for portal in get_tree().get_nodes_in_group(ENDPORTALS_GROUP):
@@ -29,7 +31,10 @@ func _hook_portals() -> void:
 		# Avoid connecting the same object several times.
 		if portal.is_connected("body_entered", self, "_on_endportal_body_entered"):
 			continue
-		portal.connect("body_entered", self, "_on_endportal_body_entered", [ portal.next_level, portal ])
+		portal.connect(
+			"body_entered", self, "_on_endportal_body_entered", [portal.next_level, portal]
+		)
+
 
 func _on_build() -> void:
 	# If there is a child named TileMap, place a block.
@@ -50,19 +55,20 @@ func _on_build() -> void:
 		elif target_cell_v == 1:
 			# If the cell has a block in in, break the block.
 			$TileMap.set_cell(target_tile_x, target_tile_y, 0)
-		
 
-func _on_endportal_body_entered(body : Node2D, next_level : PackedScene, portal : EndPortal) -> void:
+
+func _on_endportal_body_entered(body: Node2D, next_level: PackedScene, portal: EndPortal) -> void:
 	var animation = portal.on_portal_enter()
-	body.visible = false;
-	yield(animation, "animation_finished");
+	body.visible = false
+	yield(animation, "animation_finished")
 	call_deferred("_finish_level", next_level)
-	body.visible = true;
+	body.visible = true
 
-func _finish_level(next_level : PackedScene = null) -> void:
+
+func _finish_level(next_level: PackedScene = null) -> void:
 	# Create the new level, insert it into the tree and remove the old one.
 	# If next_level is null, return to the hub
-	var new_level : TileMap = next_level.instance() if next_level != null else hub
+	var new_level: TileMap = next_level.instance() if next_level != null else hub
 	add_child_below_node(level, new_level)
 	if level == hub:
 		remove_child(level)
@@ -74,8 +80,8 @@ func _finish_level(next_level : PackedScene = null) -> void:
 	# Do not forget to hook the new portals
 	_hook_portals()
 
-	#Removing instructions 
-	$UI/UI/RichTextLabel.visible = false;
+	#Removing instructions
+	$UI/UI/RichTextLabel.visible = false
 
 	# We need to flash the player out and in the tree to avoid physics errors.
 	remove_child(player)
@@ -84,21 +90,30 @@ func _finish_level(next_level : PackedScene = null) -> void:
 	player.look_right()
 	EventBus.emit_signal("level_started", {})
 
+
 func _get_player_spawn_position() -> Vector2:
 	var spawn_points = get_tree().get_nodes_in_group(SPAWNPOINTS_GROUP)
 	return spawn_points[0].global_position if len(spawn_points) > 0 else player.global_position
 
-func _on_crt_toggle (on:bool) -> void:
-	if on:
-		container.material.shader=crt_shader
-	else:
-		container.material.shader=null
 
-func _on_volume_change (bus) -> void:
+func _on_crt_toggle(on: bool) -> void:
+	if on:
+		container.material.shader = crt_shader
+	else:
+		container.material.shader = null
+
+
+func _on_volume_change(bus) -> void:
 	match str(bus):
 		"game":
-			AudioServer.set_bus_volume_db(AudioServer.get_bus_index("Master"),linear2db(Settings.volume_game/10.0))
+			AudioServer.set_bus_volume_db(
+				AudioServer.get_bus_index("Master"), linear2db(Settings.volume_game / 10.0)
+			)
 		"music":
-			AudioServer.set_bus_volume_db(AudioServer.get_bus_index("music"),linear2db(Settings.volume_music/10.0))
+			AudioServer.set_bus_volume_db(
+				AudioServer.get_bus_index("music"), linear2db(Settings.volume_music / 10.0)
+			)
 		"sfx":
-			AudioServer.set_bus_volume_db(AudioServer.get_bus_index("sfx"),linear2db(Settings.volume_sfx/10.0))
+			AudioServer.set_bus_volume_db(
+				AudioServer.get_bus_index("sfx"), linear2db(Settings.volume_sfx / 10.0)
+			)

--- a/scripts/Platform.gd
+++ b/scripts/Platform.gd
@@ -4,7 +4,7 @@
 # if you want a way to make it go away
 # For some reason, when you jump into it, it falls with you.
 # Don't know how to fix that.
-# 
+#
 # Platform asset by Hawier at https://hawier.itch.io/hawier-platformer-pack
 extends Enemy
 class_name Platform
@@ -25,11 +25,12 @@ onready var _ray := $RayCast2D
 func _ready():
 	pass
 
+
 func move(_delta: float):
 	_motion.x = clamp(_motion.x, -max_speed, max_speed)
 	_motion.x = direction * max_speed
 	_motion = move_and_slide(_motion, UP)
-	
+
 	_ray.cast_to.x = -1 * direction * RAY_CAST_DISTANCE
 	_ray.force_raycast_update()
 	if _ray.is_colliding():

--- a/scripts/Player.gd
+++ b/scripts/Player.gd
@@ -14,30 +14,31 @@ const COYOTE_TIME = 0.1
 const JUMP_BUFFER_TIME = 0.05
 const SLIP_RANGE = 16
 
-export (PackedScene) var default_projectile :PackedScene= preload("res://scenes/CoinProjectile.tscn")
+export(PackedScene) var default_projectile: PackedScene = preload("res://scenes/CoinProjectile.tscn")
 
-var coyote_timer = COYOTE_TIME # used to give a bit of extra-time to jump after leaving the ground
-var jump_buffer_timer = 0 # gives a bit of buffer to hit the jump button before landing
+var coyote_timer = COYOTE_TIME  # used to give a bit of extra-time to jump after leaving the ground
+var jump_buffer_timer = 0  # gives a bit of buffer to hit the jump button before landing
 var motion = Vector2()
-var gravity_multiplier = 1 # used for jump height variability
+var gravity_multiplier = 1  # used for jump height variability
 var double_jump = true
 var crouching = false
 var grounded = false
-var anticipating_jump = false # the small window of time before the player jumps
+var anticipating_jump = false  # the small window of time before the player jumps
 
 onready var sprite = $Sprite
 onready var tween = $Tween
 onready var trail = $Trail
 onready var run_particles = $RunParticles
 
-onready var original_scale = sprite.scale;
-onready var squash_scale = Vector2(original_scale.x*1.4, original_scale.y*0.4)
+onready var original_scale = sprite.scale
+onready var squash_scale = Vector2(original_scale.x * 1.4, original_scale.y * 0.4)
 onready var stretch_scale = Vector2(original_scale.x * 0.4, original_scale.y * 1.4)
 
-func _physics_process(delta : float) -> void:
+
+func _physics_process(delta: float) -> void:
 	if Input.is_action_just_pressed("Build"):
 		EventBus.emit_signal("build_block")
-	
+
 	var max_speed_modifier = 1
 	var acceleration_modifier = 1
 	var animationSpeed = 8
@@ -58,7 +59,7 @@ func _physics_process(delta : float) -> void:
 		sprite.play("run")
 		run_particles.emitting = true
 		look_left()
-	else:	
+	else:
 		sprite.play("idle")
 		run_particles.emitting = false
 		motion.x = lerp(motion.x, 0, 0.2)
@@ -92,16 +93,16 @@ func _physics_process(delta : float) -> void:
 		if Input.is_action_pressed("jump"):
 			gravity_multiplier = 0.5
 		else:
-			gravity_multiplier = 1 
+			gravity_multiplier = 1
 		sprite.play("jump")
 		run_particles.emitting = false
 
 	if crouching and not Input.is_action_pressed("down"):
 		crouching = false
 		unsquash()
-		
+
 	motion.y += GRAVITY * gravity_multiplier
-	
+
 	if motion.y > MAXFALLSPEED:
 		motion.y = MAXFALLSPEED
 
@@ -112,42 +113,50 @@ func _physics_process(delta : float) -> void:
 
 	var slipped = false
 	# try slipping around block corners when jumping or crossing gaps
-	if slide_count: slipped = try_slip(get_slide_collision(slide_count-1).get_angle())
+	if slide_count:
+		slipped = try_slip(get_slide_collision(slide_count - 1).get_angle())
 	# apply original result if no valid slip found
-	if !slipped: motion = move_and_slide_result
+	if !slipped:
+		motion = move_and_slide_result
+
 
 func try_slip(angle: float):
-	if angle == 0: return false
+	if angle == 0:
+		return false
 	var axis = "x" if is_equal_approx(angle, PI) else "y"
 	# is_equal_approx(abs(collision_angle - PI), PI/2)
-	var original_v = position[axis] # remember original value on axis
+	var original_v = position[axis]  # remember original value on axis
 	# check collisions in nearby positions within SLIP_RANGE
 	for r in range(1, SLIP_RANGE):
 		for p in [-1, 1]:
 			position[axis] = original_v + r * p
 			move_and_slide(motion, UP)
-			if(get_slide_count() == 0): return true # if no collision, return success
+			if get_slide_count() == 0:
+				return true  # if no collision, return success
 	# restore original value on axis if couldn't find a slip
 	position[axis] = original_v
 	return false
 
-func _input(event :InputEvent):
+
+func _input(event: InputEvent):
 	# Remove one coin and spawn a projectile
 	# Continus shooting after 0 coins
 	if event.is_action_pressed("shoot"):
-		EventBus.emit_signal("coin_collected", { "value": -1, "type": "gold" })
+		EventBus.emit_signal("coin_collected", {"value": -1, "type": "gold"})
 		shoot(default_projectile)
+
 
 func crouch():
 	crouching = true
 	squash()
+
 
 func jump():
 	tween.stop_all()
 	anticipating_jump = true
 	squash(0.03, 0, 0.5)
 	yield(tween, "tween_all_completed")
-	stretch(0.2, 0, 0.5, 1.2);
+	stretch(0.2, 0, 0.5, 1.2)
 	jump_buffer_timer = 0
 	coyote_timer = 0
 	motion.y = -JUMPFORCE
@@ -155,75 +164,91 @@ func jump():
 	$JumpSFX.play()
 	emit_signal("jumping")
 
+
 func land():
 	squash(0.05)
 	yield(tween, "tween_all_completed")
 	if grounded and not anticipating_jump:
 		unsquash(0.18)
 
-func shoot(projectile_scene :PackedScene):
+
+func shoot(projectile_scene: PackedScene):
 	# Spawn the projectile and move it to its origin point
 	# Origin is affected by changes to Sprite (ex: squashing)
-	var projectile= projectile_scene.instance()
+	var projectile = projectile_scene.instance()
 	get_parent().add_child(projectile)
-	projectile.position= $Sprite/ShootOrigin.global_position
+	projectile.position = $Sprite/ShootOrigin.global_position
 	# Projectile handles movement
 	var shoot_dir := Vector2.LEFT if sprite.flip_h else Vector2.RIGHT
 	projectile.start_moving(shoot_dir)
 	emit_signal("shooting")
 
+
 func look_right():
 	sprite.flip_h = false
+
 
 func look_left():
 	sprite.flip_h = true
 
-func squash(time=0.1, _returnDelay=0, squash_modifier=1.0):
+
+func squash(time = 0.1, _returnDelay = 0, squash_modifier = 1.0):
 	tween.remove_all()
 	tween.interpolate_property(
-		sprite, "scale",
+		sprite,
+		"scale",
 		original_scale,
 		lerp(original_scale, squash_scale, squash_modifier),
-		time, Tween.TRANS_BACK, Tween.EASE_OUT
+		time,
+		Tween.TRANS_BACK,
+		Tween.EASE_OUT
 	)
 	tween.interpolate_property(
-		trail, "height",
-		trail.height,
-		20 * squash_modifier,
-		time, Tween.TRANS_BACK, Tween.EASE_OUT
+		trail, "height", trail.height, 20 * squash_modifier, time, Tween.TRANS_BACK, Tween.EASE_OUT
 	)
 	tween.start()
 
-func stretch(time=0.2, _returnDelay=0, squash_modifier=1.0, stretch_modifier=1.0):
+
+func stretch(time = 0.2, _returnDelay = 0, squash_modifier = 1.0, stretch_modifier = 1.0):
 	tween.remove_all()
 	tween.interpolate_property(
-		sprite, "scale",
+		sprite,
+		"scale",
 		lerp(original_scale, squash_scale, squash_modifier),
-		lerp(original_scale, stretch_scale, stretch_modifier), 
-		time, Tween.TRANS_BACK, Tween.EASE_OUT
+		lerp(original_scale, stretch_scale, stretch_modifier),
+		time,
+		Tween.TRANS_BACK,
+		Tween.EASE_OUT
 	)
 	tween.interpolate_property(
-		sprite, "scale",
+		sprite,
+		"scale",
 		lerp(original_scale, stretch_scale, stretch_modifier),
 		original_scale,
-		time, Tween.TRANS_BACK, Tween.EASE_OUT, time/2)
+		time,
+		Tween.TRANS_BACK,
+		Tween.EASE_OUT,
+		time / 2
+	)
 	tween.start()
 
-func unsquash(time=0.1, _returnDelay=0, squash_modifier=1.0):
+
+func unsquash(time = 0.1, _returnDelay = 0, squash_modifier = 1.0):
 	tween.remove_all()
 	tween.interpolate_property(
-		sprite, "scale",
+		sprite,
+		"scale",
 		lerp(original_scale, squash_scale, squash_modifier),
 		original_scale,
-		time, Tween.TRANS_BACK, Tween.EASE_OUT
+		time,
+		Tween.TRANS_BACK,
+		Tween.EASE_OUT
 	)
 	tween.interpolate_property(
-		trail, "height",
-		trail.height,
-		0,
-		time, Tween.TRANS_BACK, Tween.EASE_OUT
+		trail, "height", trail.height, 0, time, Tween.TRANS_BACK, Tween.EASE_OUT
 	)
-	tween.start();
+	tween.start()
+
 
 func bounce(strength = 1100):
 	squash(0.075)

--- a/scripts/PlayerProjectile.gd
+++ b/scripts/PlayerProjectile.gd
@@ -4,35 +4,40 @@ class_name PlayerProjectile
 # Emitted before deletion.
 signal destroyed
 
-export (float) var projectile_speed := 20.0
-export (bool) var look_at_direction := true
+export(float) var projectile_speed := 20.0
+export(bool) var look_at_direction := true
 
 var _direction := Vector2()
 var _active := false
 
+
 func _ready():
 	self.connect("body_entered", self, "_body_entered")
 
+
 # This is called by the player to set things in motion
-func start_moving(dir :Vector2= Vector2()):
+func start_moving(dir: Vector2 = Vector2()):
 	_handle_start(dir)
-	_active= true
-	_direction= dir.normalized()
-	
+	_active = true
+	_direction = dir.normalized()
+
 
 # Override this to play sounds or other animations
-func _handle_start(_dir :Vector2):
+func _handle_start(_dir: Vector2):
 	pass
 
-func _physics_process(_delta :float):
+
+func _physics_process(_delta: float):
 	if _active:
 		_handle_movement()
 		if look_at_direction and _direction != Vector2():
 			look_at(position + _direction)
 
+
 # Override to do anything else than move in a straight line
 func _handle_movement():
-	position+= _direction * projectile_speed
+	position += _direction * projectile_speed
+
 
 func _body_entered(body):
 	# If whatever we touched is an enemy and it can be killed, kill it.
@@ -40,17 +45,19 @@ func _body_entered(body):
 		body.kill(self)
 	destroy()
 
+
 func destroy():
 	if not _active:
 		return
 	set_deferred("monitorable", false)
 	set_deferred("monitoring", false)
-	_active= false
+	_active = false
 	var res = _handle_destruction()
 	if res is GDScriptFunctionState:
 		yield(res, "completed")
 	emit_signal("destroyed")
 	queue_free()
+
 
 # Override to add fancy effects
 func _handle_destruction():

--- a/scripts/ScreenShake.gd
+++ b/scripts/ScreenShake.gd
@@ -14,11 +14,11 @@ onready var _duration_timer: Timer = $Duration
 
 
 func start(duration = 0.2, frequency = 15, amplitude = 16, priority = 0):
-	if (priority < self.priority):
+	if priority < self.priority:
 		return
-		
+
 	if !Settings.screen_shake:
-		return;
+		return
 
 	self.priority = priority
 	self.amplitude = amplitude
@@ -36,12 +36,16 @@ func _new_shake():
 	rand.x = rand_range(-amplitude, amplitude)
 	rand.y = rand_range(-amplitude, amplitude)
 
-	_tween.interpolate_property(camera, "offset", camera.offset, rand, _freq_timer.wait_time, TRANS, EASE)
+	_tween.interpolate_property(
+		camera, "offset", camera.offset, rand, _freq_timer.wait_time, TRANS, EASE
+	)
 	_tween.start()
 
 
 func _reset():
-	_tween.interpolate_property(camera, "offset", camera.offset, Vector2.ZERO, _freq_timer.wait_time, TRANS, EASE)
+	_tween.interpolate_property(
+		camera, "offset", camera.offset, Vector2.ZERO, _freq_timer.wait_time, TRANS, EASE
+	)
 	_tween.start()
 
 	priority = 0

--- a/scripts/Trail.gd
+++ b/scripts/Trail.gd
@@ -1,10 +1,11 @@
 extends Line2D
 
-export(int) var trail_length = 5;
+export(int) var trail_length = 5
 var positions = []
 var height = 0.0
 
 onready var parent = get_parent()
+
 
 func _process(_delta):
 	global_position = Vector2(0, 0)

--- a/ui/AchievementGet.gd
+++ b/ui/AchievementGet.gd
@@ -3,10 +3,12 @@ extends RichTextLabel
 var coinsSinceStartingLevel := 0
 var currentLevel = 0
 
+
 func _ready():
 	EventBus.connect("coin_collected", self, "_on_coin_collected")
 	EventBus.connect("level_completed", self, "_on_level_completed")
-  
+
+
 func _on_coin_collected(data):
 	var value := 1
 	if data and data.value:
@@ -15,25 +17,34 @@ func _on_coin_collected(data):
 	print("checking coin achievements")
 	get_achievements()
 
+
 func get_achievements():
 	print("getting achievements")
 	var dir = Directory.new()
 	if (dir.open("res://Achievements")) == OK:
-		if dir.open("res://Achievements/Level" + str(currentLevel)) == OK: 
-			#We are now in the folder for the achievements in this level. 
+		if dir.open("res://Achievements/Level" + str(currentLevel)) == OK:
+			#We are now in the folder for the achievements in this level.
 			dir.list_dir_begin()
 			var file_name = dir.get_next()
 			print(file_name)
 			while file_name != "":
 				if !dir.current_is_dir():
-					var current = load("res://Achievements/Level" + str(currentLevel) + "/" + file_name);
+					var current = load(
+						"res://Achievements/Level" + str(currentLevel) + "/" + file_name
+					)
 					#We now have a reference to the achievement. Check if its the right kind
 					if current is Achievement:
 						if current is CoinsAchievement:
 							#This is a coins achievement in this level. Do we have the right number of coins?
 							if coinsSinceStartingLevel == current.coinsRequired:
 								print("this is a coins achievement")
-								self.append_bbcode("[rainbow][center]" + current.description + "[/center][/rainbow]")
+								self.append_bbcode(
+									(
+										"[rainbow][center]"
+										+ current.description
+										+ "[/center][/rainbow]"
+									)
+								)
 								clear_text_after_seconds()
 				file_name = dir.get_next()
 		else:
@@ -41,7 +52,8 @@ func get_achievements():
 	else:
 		print("the requested directory does not exist")
 
-func clear_text_after_seconds(): 
+
+func clear_text_after_seconds():
 	var t = Timer.new()
 	t.set_wait_time(3.25)
 	t.set_one_shot(true)
@@ -49,7 +61,7 @@ func clear_text_after_seconds():
 	t.start()
 	yield(t, "timeout")
 	self.clear()
-	
+
 
 func _on_level_completed(data):
 	coinsSinceStartingLevel = 0

--- a/ui/CoinCount.gd
+++ b/ui/CoinCount.gd
@@ -2,13 +2,18 @@ extends RichTextLabel
 
 var count := 0
 
+
 func _ready():
 	EventBus.connect("coin_collected", self, "_on_coin_collected")
-  
+
+
 func _on_coin_collected(data):
 	var value := 1
 	if data.has("value"):
 		value = data["value"]
 
 	count += value
-	bbcode_text = "\n[wave amp=50 freq=2]COINS:[rainbow freq=0.5 sat=1 val=20]%d[/rainbow][/wave]" % count
+	bbcode_text = (
+		"\n[wave amp=50 freq=2]COINS:[rainbow freq=0.5 sat=1 val=20]%d[/rainbow][/wave]"
+		% count
+	)

--- a/ui/LevelCount.gd
+++ b/ui/LevelCount.gd
@@ -3,16 +3,22 @@ extends RichTextLabel
 const VisibleTime = 2
 var currentLevel := 1
 
+
 func _ready():
 	EventBus.connect("level_started", self, "_on_level_started")
 	EventBus.connect("level_completed", self, "_on_level_completed")
 	_on_level_started({})
-  
+
+
 func _on_level_started(data):
 	self.show()
-	bbcode_text = "\n[wave amp=50 freq=2]LEVEL:[rainbow freq=0.5 sat=1 val=20]%d[/rainbow][/wave]" % currentLevel
+	bbcode_text = (
+		"\n[wave amp=50 freq=2]LEVEL:[rainbow freq=0.5 sat=1 val=20]%d[/rainbow][/wave]"
+		% currentLevel
+	)
 	yield(get_tree().create_timer(VisibleTime), "timeout")
 	self.hide()
+
 
 func _on_level_completed(data):
 	currentLevel += 1

--- a/ui/PauseMenu.gd
+++ b/ui/PauseMenu.gd
@@ -2,220 +2,324 @@
 
 extends CanvasLayer
 
-onready var label_back = get_node("PauseMenu/MainMenu/BackLabel");
-onready var label_gfx = get_node("PauseMenu/MainMenu/GFXLabel");
-onready var label_sfx = get_node("PauseMenu/MainMenu/SFXLabel");
-onready var label_restart = get_node("PauseMenu/MainMenu/RestartLabel");
+onready var label_back = get_node("PauseMenu/MainMenu/BackLabel")
+onready var label_gfx = get_node("PauseMenu/MainMenu/GFXLabel")
+onready var label_sfx = get_node("PauseMenu/MainMenu/SFXLabel")
+onready var label_restart = get_node("PauseMenu/MainMenu/RestartLabel")
 
-onready var label_gfxback = get_node("PauseMenu/GFXMenu/BackLabel");
-onready var label_camlean = get_node("PauseMenu/GFXMenu/CamLeanLabel");
-onready var label_shake = get_node("PauseMenu/GFXMenu/ShakeLabel");
-onready var label_crt = get_node("PauseMenu/GFXMenu/CRTLabel");
+onready var label_gfxback = get_node("PauseMenu/GFXMenu/BackLabel")
+onready var label_camlean = get_node("PauseMenu/GFXMenu/CamLeanLabel")
+onready var label_shake = get_node("PauseMenu/GFXMenu/ShakeLabel")
+onready var label_crt = get_node("PauseMenu/GFXMenu/CRTLabel")
 
-onready var label_sfxback = get_node("PauseMenu/SFXMenu/BackLabel");
-onready var label_volgame = get_node("PauseMenu/SFXMenu/GameVolLabel");
-onready var label_volmusic = get_node("PauseMenu/SFXMenu/MusicVolLabel");
-onready var label_volsfx = get_node("PauseMenu/SFXMenu/SFXVolLabel");
+onready var label_sfxback = get_node("PauseMenu/SFXMenu/BackLabel")
+onready var label_volgame = get_node("PauseMenu/SFXMenu/GameVolLabel")
+onready var label_volmusic = get_node("PauseMenu/SFXMenu/MusicVolLabel")
+onready var label_volsfx = get_node("PauseMenu/SFXMenu/SFXVolLabel")
 
-const CameraLeanAmount = preload("res://scripts/CameraLeanAmount.gd");
+const CameraLeanAmount = preload("res://scripts/CameraLeanAmount.gd")
 
-enum PAUSE_MENU {MAIN,GFX,SFX,RESTART}
-var current_menu : int = PAUSE_MENU.MAIN;
-var element_selected : int = 0;
+enum PAUSE_MENU { MAIN, GFX, SFX, RESTART }
+var current_menu: int = PAUSE_MENU.MAIN
+var element_selected: int = 0
+
 
 func _ready() -> void:
-	$PauseMenu/MainMenu.show();
-	$PauseMenu/GFXMenu.hide();
-	$PauseMenu/SFXMenu.hide();
-	$PauseMenu.hide();
-	EventBus.connect("game_paused",self,"_on_pause_toggle");
-	
-func _process(_delta:float) -> void:
+	$PauseMenu/MainMenu.show()
+	$PauseMenu/GFXMenu.hide()
+	$PauseMenu/SFXMenu.hide()
+	$PauseMenu.hide()
+	EventBus.connect("game_paused", self, "_on_pause_toggle")
+
+
+func _process(_delta: float) -> void:
 	if Input.is_action_just_pressed("pause"):
-		EventBus.emit_signal("game_paused",!get_tree().paused);
+		EventBus.emit_signal("game_paused", !get_tree().paused)
 	else:
 		if $PauseMenu.visible:
 			if Input.is_action_just_pressed("ui_down"):
-				element_selected=(element_selected+1)%get_element_count();
-				set_active_element_style();
+				element_selected = (element_selected + 1) % get_element_count()
+				set_active_element_style()
 			elif Input.is_action_just_pressed("ui_up"):
 				if 0 < element_selected:
-					element_selected=element_selected-1;
+					element_selected = element_selected - 1
 				else:
-					element_selected=get_element_count()-1;
-				set_active_element_style();
+					element_selected = get_element_count() - 1
+				set_active_element_style()
 			elif Input.is_action_just_pressed("ui_left"):
 				#camera lean selection
 				if 1 == element_selected && PAUSE_MENU.GFX == current_menu:
-					cam_lean_select(-1);
+					cam_lean_select(-1)
 				#screen shake selection
-				if 2== element_selected && PAUSE_MENU.GFX == current_menu:
-					Settings.screen_shake=!Settings.screen_shake;
-					label_shake.text="\nSCREEN SHAKE: " + ("ON" if Settings.screen_shake else "OFF");
-					set_active_element_style();
+				if 2 == element_selected && PAUSE_MENU.GFX == current_menu:
+					Settings.screen_shake = !Settings.screen_shake
+					label_shake.text = (
+						"\nSCREEN SHAKE: "
+						+ ("ON" if Settings.screen_shake else "OFF")
+					)
+					set_active_element_style()
 				#crt filter selection
 				elif 3 == element_selected && PAUSE_MENU.GFX == current_menu:
-					Settings.crt_filter=!Settings.crt_filter;
-					label_crt.text="\nCRT FILTER: " + ("ON" if Settings.crt_filter else "OFF");
-					set_active_element_style();
-					EventBus.emit_signal("crt_filter_toggle",Settings.crt_filter);
+					Settings.crt_filter = !Settings.crt_filter
+					label_crt.text = "\nCRT FILTER: " + ("ON" if Settings.crt_filter else "OFF")
+					set_active_element_style()
+					EventBus.emit_signal("crt_filter_toggle", Settings.crt_filter)
 				elif 0 < element_selected && PAUSE_MENU.SFX == current_menu:
-					vol_select(element_selected,-1);
+					vol_select(element_selected, -1)
 			elif Input.is_action_just_pressed("ui_right"):
 				#camera lean selection
 				if 1 == element_selected && PAUSE_MENU.GFX == current_menu:
-					cam_lean_select(1);
+					cam_lean_select(1)
 				#screen shake selection
-				if 2== element_selected && PAUSE_MENU.GFX == current_menu:
-					Settings.screen_shake=!Settings.screen_shake;
-					label_shake.text="\nSCREEN SHAKE: " + ("ON" if Settings.screen_shake else "OFF");
-					set_active_element_style();
+				if 2 == element_selected && PAUSE_MENU.GFX == current_menu:
+					Settings.screen_shake = !Settings.screen_shake
+					label_shake.text = (
+						"\nSCREEN SHAKE: "
+						+ ("ON" if Settings.screen_shake else "OFF")
+					)
+					set_active_element_style()
 				#crt filter selection
 				elif 3 == element_selected && PAUSE_MENU.GFX == current_menu:
-					Settings.crt_filter=!Settings.crt_filter;
-					label_crt.text="\nCRT FILTER: " + ("ON" if Settings.crt_filter else "OFF");
-					set_active_element_style();
-					EventBus.emit_signal("crt_filter_toggle",Settings.crt_filter);
+					Settings.crt_filter = !Settings.crt_filter
+					label_crt.text = "\nCRT FILTER: " + ("ON" if Settings.crt_filter else "OFF")
+					set_active_element_style()
+					EventBus.emit_signal("crt_filter_toggle", Settings.crt_filter)
 				elif 0 < element_selected && PAUSE_MENU.SFX == current_menu:
-					vol_select(element_selected,1);
+					vol_select(element_selected, 1)
 			elif Input.is_action_just_pressed("ui_accept"):
 				match current_menu:
-					PAUSE_MENU.MAIN: main_menu_accept();
-					PAUSE_MENU.GFX: gfx_menu_accept();
-					PAUSE_MENU.SFX: sfx_menu_accept();
+					PAUSE_MENU.MAIN:
+						main_menu_accept()
+					PAUSE_MENU.GFX:
+						gfx_menu_accept()
+					PAUSE_MENU.SFX:
+						sfx_menu_accept()
+
 
 # data: whether or not we want the game to be paused
-func _on_pause_toggle (data:bool) -> void:
+func _on_pause_toggle(data: bool) -> void:
 	if data:
-		$PauseMenu.show();
-		set_active_element_style();
+		$PauseMenu.show()
+		set_active_element_style()
 	else:
-		element_selected=0;
-		current_menu=0;
-		$PauseMenu/MainMenu.show();
-		$PauseMenu/GFXMenu.hide();
-		$PauseMenu/SFXMenu.hide();
-		$PauseMenu.hide();
-	get_tree().paused=data;
+		element_selected = 0
+		current_menu = 0
+		$PauseMenu/MainMenu.show()
+		$PauseMenu/GFXMenu.hide()
+		$PauseMenu/SFXMenu.hide()
+		$PauseMenu.hide()
+	get_tree().paused = data
+
 
 #note [jam] : this is a dumb way of getting the total list of menu items - oh well
-func get_element_count () -> int:
+func get_element_count() -> int:
 	match current_menu:
-		PAUSE_MENU.MAIN: return 4;
-		PAUSE_MENU.GFX: return 4;
-		PAUSE_MENU.SFX: return 4;
-	return 1;
+		PAUSE_MENU.MAIN:
+			return 4
+		PAUSE_MENU.GFX:
+			return 4
+		PAUSE_MENU.SFX:
+			return 4
+	return 1
 
-func set_active_element_style () -> void:
+
+func set_active_element_style() -> void:
 	if PAUSE_MENU.MAIN == current_menu:
-		label_back.bbcode_text=label_back.text;
-		label_gfx.bbcode_text=label_gfx.text;
-		label_sfx.bbcode_text=label_sfx.text;
-		label_restart.bbcode_text=label_restart.text;
+		label_back.bbcode_text = label_back.text
+		label_gfx.bbcode_text = label_gfx.text
+		label_sfx.bbcode_text = label_sfx.text
+		label_restart.bbcode_text = label_restart.text
 
 		match element_selected:
-			0: label_back.bbcode_text="[color=yellow][wave amp=25 freq=1]"+str(label_back.text)+"[/wave][/color]";
-			1: label_gfx.bbcode_text="[color=yellow][wave amp=25 freq=1]"+str(label_gfx.text)+"[/wave][/color]";
-			2: label_sfx.bbcode_text="[color=yellow][wave amp=25 freq=1]"+str(label_sfx.text)+"[/wave][/color]";
-			3: label_restart.bbcode_text="[color=yellow][wave amp=25 freq=1]"+str(label_restart.text)+"[/wave][/color]";
+			0:
+				label_back.bbcode_text = (
+					"[color=yellow][wave amp=25 freq=1]"
+					+ str(label_back.text)
+					+ "[/wave][/color]"
+				)
+			1:
+				label_gfx.bbcode_text = (
+					"[color=yellow][wave amp=25 freq=1]"
+					+ str(label_gfx.text)
+					+ "[/wave][/color]"
+				)
+			2:
+				label_sfx.bbcode_text = (
+					"[color=yellow][wave amp=25 freq=1]"
+					+ str(label_sfx.text)
+					+ "[/wave][/color]"
+				)
+			3:
+				label_restart.bbcode_text = (
+					"[color=yellow][wave amp=25 freq=1]"
+					+ str(label_restart.text)
+					+ "[/wave][/color]"
+				)
 	elif PAUSE_MENU.GFX == current_menu:
-		label_gfxback.bbcode_text=label_gfxback.text;
-		label_camlean.bbcode_text=label_camlean.text;
-		label_shake.bbcode_text=label_shake.text;
-		label_crt.bbcode_text=label_crt.text;
+		label_gfxback.bbcode_text = label_gfxback.text
+		label_camlean.bbcode_text = label_camlean.text
+		label_shake.bbcode_text = label_shake.text
+		label_crt.bbcode_text = label_crt.text
 
 		match element_selected:
-			0: label_gfxback.bbcode_text="[color=yellow][wave amp=25 freq=1]"+str(label_gfxback.text)+"[/wave][/color]";
-			1: label_camlean.bbcode_text="[color=yellow][wave amp=25 freq=1]"+str(label_camlean.text)+"[/wave][/color]";
-			2: label_shake.bbcode_text="[color=yellow][wave amp=25 freq=1]"+str(label_shake.text)+"[/wave][/color]";
-			3: label_crt.bbcode_text="[color=yellow][wave amp=25 freq=1]"+str(label_crt.text)+"[/wave][/color]";
+			0:
+				label_gfxback.bbcode_text = (
+					"[color=yellow][wave amp=25 freq=1]"
+					+ str(label_gfxback.text)
+					+ "[/wave][/color]"
+				)
+			1:
+				label_camlean.bbcode_text = (
+					"[color=yellow][wave amp=25 freq=1]"
+					+ str(label_camlean.text)
+					+ "[/wave][/color]"
+				)
+			2:
+				label_shake.bbcode_text = (
+					"[color=yellow][wave amp=25 freq=1]"
+					+ str(label_shake.text)
+					+ "[/wave][/color]"
+				)
+			3:
+				label_crt.bbcode_text = (
+					"[color=yellow][wave amp=25 freq=1]"
+					+ str(label_crt.text)
+					+ "[/wave][/color]"
+				)
 	elif PAUSE_MENU.SFX == current_menu:
-		label_sfxback.bbcode_text=label_sfxback.text;
-		label_volgame.bbcode_text=label_volgame.text;
-		label_volmusic.bbcode_text=label_volmusic.text;
-		label_volsfx.bbcode_text=label_volsfx.text;
-		
-		match element_selected:
-			0: label_sfxback.bbcode_text="[color=yellow][wave amp=25 freq=1]"+str(label_sfxback.text)+"[/wave][/color]";
-			1: label_volgame.bbcode_text="[color=yellow][wave amp=25 freq=1]"+str(label_volgame.text)+"[/wave][/color]";
-			2: label_volmusic.bbcode_text="[color=yellow][wave amp=25 freq=1]"+str(label_volmusic.text)+"[/wave][/color]";
-			3: label_volsfx.bbcode_text="[color=yellow][wave amp=25 freq=1]"+str(label_volsfx.text)+"[/wave][/color]";
+		label_sfxback.bbcode_text = label_sfxback.text
+		label_volgame.bbcode_text = label_volgame.text
+		label_volmusic.bbcode_text = label_volmusic.text
+		label_volsfx.bbcode_text = label_volsfx.text
 
-func main_menu_accept () -> void:
+		match element_selected:
+			0:
+				label_sfxback.bbcode_text = (
+					"[color=yellow][wave amp=25 freq=1]"
+					+ str(label_sfxback.text)
+					+ "[/wave][/color]"
+				)
+			1:
+				label_volgame.bbcode_text = (
+					"[color=yellow][wave amp=25 freq=1]"
+					+ str(label_volgame.text)
+					+ "[/wave][/color]"
+				)
+			2:
+				label_volmusic.bbcode_text = (
+					"[color=yellow][wave amp=25 freq=1]"
+					+ str(label_volmusic.text)
+					+ "[/wave][/color]"
+				)
+			3:
+				label_volsfx.bbcode_text = (
+					"[color=yellow][wave amp=25 freq=1]"
+					+ str(label_volsfx.text)
+					+ "[/wave][/color]"
+				)
+
+
+func main_menu_accept() -> void:
 	match element_selected:
 		0:
-			EventBus.emit_signal("game_paused",false);
+			EventBus.emit_signal("game_paused", false)
 		1:
-			$PauseMenu/MainMenu.hide();
-			$PauseMenu/GFXMenu.show();
-			current_menu=PAUSE_MENU.GFX;
-			element_selected=0;
-			set_active_element_style();
+			$PauseMenu/MainMenu.hide()
+			$PauseMenu/GFXMenu.show()
+			current_menu = PAUSE_MENU.GFX
+			element_selected = 0
+			set_active_element_style()
 		2:
-			$PauseMenu/MainMenu.hide();
-			$PauseMenu/SFXMenu.show();
-			current_menu=PAUSE_MENU.SFX;
-			element_selected=0;
-			set_active_element_style();
+			$PauseMenu/MainMenu.hide()
+			$PauseMenu/SFXMenu.show()
+			current_menu = PAUSE_MENU.SFX
+			element_selected = 0
+			set_active_element_style()
 		3:
 			EventBus.emit_signal("game_paused", false)
 			get_tree().reload_current_scene()
 
-func gfx_menu_accept () -> void:
+
+func gfx_menu_accept() -> void:
 	match element_selected:
 		0:
-			$PauseMenu/GFXMenu.hide();
-			$PauseMenu/MainMenu.show();
-			current_menu=PAUSE_MENU.MAIN;
-			element_selected=0;
-			set_active_element_style();
-			pass;
+			$PauseMenu/GFXMenu.hide()
+			$PauseMenu/MainMenu.show()
+			current_menu = PAUSE_MENU.MAIN
+			element_selected = 0
+			set_active_element_style()
+			pass
 		1:
-			cam_lean_select(1);
+			cam_lean_select(1)
 		3:
-			Settings.crt_filter=!Settings.crt_filter;
-			label_crt.text="\nCRT FILTER: " + ("ON" if Settings.crt_filter else "OFF");
-			set_active_element_style();
-			EventBus.emit_signal("crt_filter_toggle",Settings.crt_filter);
+			Settings.crt_filter = !Settings.crt_filter
+			label_crt.text = "\nCRT FILTER: " + ("ON" if Settings.crt_filter else "OFF")
+			set_active_element_style()
+			EventBus.emit_signal("crt_filter_toggle", Settings.crt_filter)
 		2:
-			Settings.screen_shake=!Settings.screen_shake;
-			label_shake.text="\nSCREEN SHAKE: " + ("ON" if Settings.screen_shake else "OFF");
-			set_active_element_style();
-			
+			Settings.screen_shake = !Settings.screen_shake
+			label_shake.text = "\nSCREEN SHAKE: " + ("ON" if Settings.screen_shake else "OFF")
+			set_active_element_style()
 
-func cam_lean_select (delta: int) -> void:
+
+func cam_lean_select(delta: int) -> void:
 	if 1 == delta:
-		Settings.camera_lean=(Settings.camera_lean+1)%3;
+		Settings.camera_lean = (Settings.camera_lean + 1) % 3
 	else:
 		if 0 < Settings.camera_lean:
-			Settings.camera_lean=Settings.camera_lean-1;
+			Settings.camera_lean = Settings.camera_lean - 1
 		else:
-			Settings.camera_lean=CameraLeanAmount.MAX;
+			Settings.camera_lean = CameraLeanAmount.MAX
 
-	label_camlean.text="\nCAMERA LEAN: <  "+ ("OFF" if CameraLeanAmount.OFF == Settings.camera_lean else "MIN" if CameraLeanAmount.MIN == Settings.camera_lean else "MAX") +"  >"
-	set_active_element_style();
-	pass;
-	
-func sfx_menu_accept () -> void:
+	label_camlean.text = (
+		"\nCAMERA LEAN: <  "
+		+ (
+			"OFF"
+			if CameraLeanAmount.OFF == Settings.camera_lean
+			else "MIN" if CameraLeanAmount.MIN == Settings.camera_lean else "MAX"
+		)
+		+ "  >"
+	)
+	set_active_element_style()
+	pass
+
+
+func sfx_menu_accept() -> void:
 	if 0 == element_selected:
-		$PauseMenu/SFXMenu.hide();
-		$PauseMenu/MainMenu.show();
-		current_menu=PAUSE_MENU.MAIN;
-		element_selected=0;
-		set_active_element_style();
+		$PauseMenu/SFXMenu.hide()
+		$PauseMenu/MainMenu.show()
+		current_menu = PAUSE_MENU.MAIN
+		element_selected = 0
+		set_active_element_style()
 	else:
-		vol_select(element_selected,1);
-	
-func vol_select (el,delta) -> void:
+		vol_select(element_selected, 1)
+
+
+func vol_select(el, delta) -> void:
 	match el:
 		1:
-			Settings.volume_game=int(clamp(Settings.volume_game+delta,0,10));
-			label_volgame.text="\nGAME VOLUME: <  "+(" " if Settings.volume_game < 10 else "")+str(Settings.volume_game)+"  >\n";
+			Settings.volume_game = int(clamp(Settings.volume_game + delta, 0, 10))
+			label_volgame.text = (
+				"\nGAME VOLUME: <  "
+				+ (" " if Settings.volume_game < 10 else "")
+				+ str(Settings.volume_game)
+				+ "  >\n"
+			)
 		2:
-			Settings.volume_music=int(clamp(Settings.volume_music+delta,0,10));
-			label_volmusic.text="\nMUSIC VOLUME: <  "+(" " if Settings.volume_music < 10 else "")+str(Settings.volume_music)+"  >\n";
+			Settings.volume_music = int(clamp(Settings.volume_music + delta, 0, 10))
+			label_volmusic.text = (
+				"\nMUSIC VOLUME: <  "
+				+ (" " if Settings.volume_music < 10 else "")
+				+ str(Settings.volume_music)
+				+ "  >\n"
+			)
 		3:
-			Settings.volume_sfx=int(clamp(Settings.volume_sfx+delta,0,10));
-			label_volsfx.text="\n SFX VOLUME: <  "+(" " if Settings.volume_sfx < 10 else "")+str(Settings.volume_sfx)+"  >\n";
-	set_active_element_style();
-	EventBus.emit_signal("volume_changed","game" if 1==el else "music" if 2==el else "sfx");
+			Settings.volume_sfx = int(clamp(Settings.volume_sfx + delta, 0, 10))
+			label_volsfx.text = (
+				"\n SFX VOLUME: <  "
+				+ (" " if Settings.volume_sfx < 10 else "")
+				+ str(Settings.volume_sfx)
+				+ "  >\n"
+			)
+	set_active_element_style()
+	EventBus.emit_signal("volume_changed", "game" if 1 == el else "music" if 2 == el else "sfx")

--- a/ui/PauseMenu.gd
+++ b/ui/PauseMenu.gd
@@ -19,7 +19,7 @@ onready var label_volsfx = get_node("PauseMenu/SFXMenu/SFXVolLabel");
 
 const CameraLeanAmount = preload("res://scripts/CameraLeanAmount.gd");
 
-enum PAUSE_MENU {MAIN,GFX,SFX,RESTART};
+enum PAUSE_MENU {MAIN,GFX,SFX,RESTART}
 var current_menu : int = PAUSE_MENU.MAIN;
 var element_selected : int = 0;
 


### PR DESCRIPTION
See https://github.com/a-little-org-called-mario/a-little-game-called-mario/discussions/60

This makes it so, every time code gets merged into main, an opinionated Godot auto-formatter gets applied to every `.gd` file and commits the results. This PR is noisy because it contains the results of running the formatter; the YAML file is the only change I made, the rest are showing you what the autoformatter does.

It would be nice if this eventually ran on each PR instead of when code gets merged into main, but GH's privacy model for PR actions makes that *extremely* complicated. This was the easy way.

Worth noting that we don't have control over the formatter rules. Maybe we'll hate them. Maybe this tool is immature. If this is a horrible idea, we can undo it. But it also potentially provides a solid solution to both the whitespace issue and any arguments over code style.