### PR TITLE
Move the CRT effect into a screen-reading shader

### DIFF
--- a/scenes/Main.tscn
+++ b/scenes/Main.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=13 format=2]
+[gd_scene load_steps=14 format=2]
 
 [ext_resource path="res://scenes/Player.tscn" type="PackedScene" id=1]
 [ext_resource path="res://scripts/Main.gd" type="Script" id=2]
@@ -11,8 +11,9 @@
 [ext_resource path="res://ui/PauseMenu.tscn" type="PackedScene" id=9]
 [ext_resource path="res://shaders/CRT.gdshader" type="Shader" id=10]
 [ext_resource path="res://ui/TouchInputs.tscn" type="PackedScene" id=11]
+[ext_resource path="res://scripts/CRTRect.gd" type="Script" id=12]
 
-[sub_resource type="ShaderMaterial" id=2]
+[sub_resource type="ShaderMaterial" id=3]
 shader = ExtResource( 10 )
 shader_param/res = Vector2( 1024, 600 )
 shader_param/mask_type = 0
@@ -26,47 +27,44 @@ shader_param/warp = Vector2( 64, 24 )
 shader_param/maskDark = 0.5
 shader_param/maskLight = 1.5
 
-[node name="Root" type="Node"]
-
-[node name="ViewportContainer" type="ViewportContainer" parent="."]
-material = SubResource( 2 )
-margin_right = 1024.0
-margin_bottom = 600.0
-
-[node name="Main" type="Viewport" parent="ViewportContainer"]
-size = Vector2( 1024, 600 )
-handle_input_locally = false
-usage = 0
-render_target_update_mode = 3
-audio_listener_enable_2d = true
+[node name="Main" type="Node2D"]
 script = ExtResource( 2 )
 
-[node name="Camera" type="Camera2D" parent="ViewportContainer/Main"]
+[node name="Camera" type="Camera2D" parent="."]
 rotating = true
 current = true
 script = ExtResource( 6 )
 
-[node name="ScreenShake" parent="ViewportContainer/Main/Camera" instance=ExtResource( 5 )]
+[node name="ScreenShake" parent="Camera" instance=ExtResource( 5 )]
 
-[node name="Player" parent="ViewportContainer/Main" instance=ExtResource( 1 )]
+[node name="Player" parent="." instance=ExtResource( 1 )]
 position = Vector2( 159, 443 )
 
-[node name="TileMap" parent="ViewportContainer/Main" instance=ExtResource( 4 )]
+[node name="TileMap" parent="." instance=ExtResource( 4 )]
 
-[node name="UI" parent="ViewportContainer/Main" instance=ExtResource( 3 )]
+[node name="UI" parent="." instance=ExtResource( 3 )]
 
-[node name="PauseMenu" parent="ViewportContainer/Main" instance=ExtResource( 9 )]
+[node name="PauseMenu" parent="." instance=ExtResource( 9 )]
 
-[node name="Transition" parent="ViewportContainer/Main" instance=ExtResource( 8 )]
+[node name="Transition" parent="." instance=ExtResource( 8 )]
 
-[node name="TouchInputs" parent="ViewportContainer/Main" instance=ExtResource( 11 )]
+[node name="TouchInputs" parent="." instance=ExtResource( 11 )]
 
-[node name="Music" type="Node" parent="ViewportContainer/Main"]
+[node name="CRTLayer" type="CanvasLayer" parent="."]
+layer = 10
 
-[node name="AudioStreamPlayer" type="AudioStreamPlayer" parent="ViewportContainer/Main/Music"]
+[node name="CRTRect" type="ColorRect" parent="CRTLayer"]
+material = SubResource( 3 )
+anchor_right = 1.0
+anchor_bottom = 1.0
+script = ExtResource( 12 )
+
+[node name="Music" type="Node" parent="."]
+
+[node name="AudioStreamPlayer" type="AudioStreamPlayer" parent="Music"]
 stream = ExtResource( 7 )
 volume_db = -20.0
 autoplay = true
 bus = "music"
 
-[connection signal="jumping" from="ViewportContainer/Main/Player" to="ViewportContainer/Main/Camera" method="trigger_small_shake"]
+[connection signal="jumping" from="Player" to="Camera" method="trigger_small_shake"]

--- a/scripts/CRTRect.gd
+++ b/scripts/CRTRect.gd
@@ -1,0 +1,8 @@
+extends ColorRect
+
+func _ready() -> void:
+	EventBus.connect("crt_filter_toggle", self, "_on_crt_toggle")
+
+
+func _on_crt_toggle(on: bool) -> void:
+	visible = on

--- a/scripts/Main.gd
+++ b/scripts/Main.gd
@@ -1,4 +1,4 @@
-extends Viewport
+extends Node2D
 
 const SPAWNPOINTS_GROUP: String = "SpawnPoints"
 const ENDPORTALS_GROUP: String = "EndPortals"
@@ -8,9 +8,6 @@ onready var hub: TileMap = $TileMap
 onready var level: TileMap = $TileMap
 onready var player: Player = $Player
 
-onready var container: ViewportContainer = get_parent()
-onready var crt_shader = preload("res://shaders/CRT.gdshader")
-
 var completionSound = preload("res://sfx/portal.wav")
 var coinSound = preload("res://sfx/coin.wav")
 
@@ -18,7 +15,6 @@ var coinSound = preload("res://sfx/coin.wav")
 func _ready() -> void:
 	EventBus.connect("build_block", self, "_on_build")
 	_hook_portals()
-	EventBus.connect("crt_filter_toggle", self, "_on_crt_toggle")
 	EventBus.connect("volume_changed", self, "_on_volume_change")
 	VisualServer.set_default_clear_color(Color.black)
 
@@ -94,13 +90,6 @@ func _finish_level(next_level: PackedScene = null) -> void:
 func _get_player_spawn_position() -> Vector2:
 	var spawn_points = get_tree().get_nodes_in_group(SPAWNPOINTS_GROUP)
 	return spawn_points[0].global_position if len(spawn_points) > 0 else player.global_position
-
-
-func _on_crt_toggle(on: bool) -> void:
-	if on:
-		container.material.shader = crt_shader
-	else:
-		container.material.shader = null
 
 
 func _on_volume_change(bus) -> void:

--- a/shaders/CRT.gdshader
+++ b/shaders/CRT.gdshader
@@ -262,15 +262,15 @@ float Bar(float pos, float bar){ pos -= bar; return pos * pos < 4.0 ? 0.0 : 1.0;
 
 // Entry.
 void fragment(){
-	vec2 coord = UV*res;
-	vec2 pos = Warp(coord.xy / (1.0 / TEXTURE_PIXEL_SIZE).xy);
+	vec2 coord = SCREEN_UV*res;
+	vec2 pos = Warp(SCREEN_UV);
 	
-	COLOR.rgb = Tri(pos, TEXTURE) * Mask(coord.xy);
-	if (bloom_type == 0){ 
-		COLOR.rgb = mix(COLOR.rgb,Bloom(pos, TEXTURE), 1.0 / bloomAmount);    
-	}else if (bloom_type == 1){
-		COLOR.rgb += Bloom(pos, TEXTURE) * 1.0 / bloomAmount;    
-	} 
+	COLOR.rgb = Tri(pos, SCREEN_TEXTURE) * Mask(coord.xy);
+	if (bloom_type == 0) {
+		COLOR.rgb = mix(COLOR.rgb,Bloom(pos, SCREEN_TEXTURE), 1.0 / bloomAmount);
+	} else if (bloom_type == 1) {
+		COLOR.rgb += Bloom(pos, SCREEN_TEXTURE) * 1.0 / bloomAmount;
+	}
 	
 	COLOR.a = 1.0;  
 	COLOR.rgb = ToSrgb(COLOR.rgb);


### PR DESCRIPTION
Instead of adding a Viewport and ViewportContainer the CRT effect is now applied using a screen-reading ColorRect, simplifying the node structure.

**_Important: Please check if everything visually looks the same as before. Also check if there is a performance drop, as I notice one on my machine._**

**Before:**

![image](https://user-images.githubusercontent.com/28286961/162630674-9a2cbaa8-1d78-46e9-ab2a-fdf3af72fa19.png)

**After:**

![image](https://user-images.githubusercontent.com/28286961/162630657-ef1368b7-be9e-46ca-b488-9b06cfc2a2cc.png)
