### PR TITLE
Fix for Platforms falling out of the sky

### DIFF
--- a/scripts/Platform.gd
+++ b/scripts/Platform.gd
@@ -30,6 +30,7 @@ func move(_delta: float):
 	_motion.x = clamp(_motion.x, -max_speed, max_speed)
 	_motion.x = direction * max_speed
 	_motion = move_and_slide(_motion, UP)
+	_motion.y = 0
 
 	_ray.cast_to.x = -1 * direction * RAY_CAST_DISTANCE
 	_ray.force_raycast_update()

--- a/scripts/Platform.gd
+++ b/scripts/Platform.gd
@@ -29,8 +29,7 @@ func _ready():
 func move(_delta: float):
 	_motion.x = clamp(_motion.x, -max_speed, max_speed)
 	_motion.x = direction * max_speed
-	_motion = move_and_slide(_motion, UP)
-	_motion.y = 0
+	move_and_collide(_motion * _delta)
 
 	_ray.cast_to.x = -1 * direction * RAY_CAST_DISTANCE
 	_ray.force_raycast_update()


### PR DESCRIPTION
Platforms are kind of unusable because bumping against them causes them to descend to the floor. This fixes that.

Platforms also pick up coins if they collide with them. This doesn't fix that, because it's funny.