### PR TITLE
fix hub finding non-level files

### DIFF
--- a/scripts/levels/Hub.gd
+++ b/scripts/levels/Hub.gd
@@ -86,7 +86,7 @@ static func _get_first_level_in_dir(path: String) -> String:
 		dir.list_dir_begin()
 		var filename := dir.get_next()
 		while filename != "":
-			if filename != "." and filename != ".." and !dir.current_is_dir():
+			if filename != "." and filename != ".." and !dir.current_is_dir() and filename.ends_with(".tscn"):
 
 				levels.append("%s/%s" % [path, filename])
 			filename = dir.get_next()


### PR DESCRIPTION
DDR_01's first file is a .gd file, which causes the label regex to break, because it is finding `Controls.gd` first.