### PR TITLE
Add alias to netlify deploy

### DIFF
--- a/.github/workflows/publish-pull-request-preview.yml
+++ b/.github/workflows/publish-pull-request-preview.yml
@@ -54,6 +54,7 @@ jobs:
           publish-dir: '.'
           github-token: ${{ secrets.GITHUB_TOKEN }}
           deploy-message: "You can test out these proposed changes!"
+          alias: pr-${{ env.PR_NUM }}
         env:
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
           NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}


### PR DESCRIPTION
This will make all deploy URLs consistent based on PR -- I think it'll be something along the lines of https://pr-100--little-mario.netlify.app. 

We might be happy with this! Otherwise, this is the precursor to setting up a custom URL.