### PR TITLE
Re-add autoformatter

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -15,8 +15,31 @@ on:
       - '.github'
 
 jobs:
+  format_code:
+    runs-on: ubuntu-latest
+    # To prevent infinite loops
+    if: "!contains(github.event.head_commit.message, 'Auto-Format GDScript'"
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.BOT_PAT }}
+
+      - uses: actions/setup-python@v3
+        with: 
+          python-version: 3.x
+
+      - run: pip3 install 'gdtoolkit==3.*'
+
+      - run: gdformat **/*.gd
+
+      - uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: Auto-Format GDScript
+          file_pattern: "**/*.gd"
+
   build_game:
     name: Build Game
+    # TODO: this had `needs: format_code`, but I'm not sure how that intersects with our if clause
     runs-on: ubuntu-latest
     steps:
       - name: checkout latest code

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -12,7 +12,7 @@ on:
       - '.gitignore'
       - 'LICENSE'
       - '**.md'
-      - '.github'
+      - '.github/**'
 
 jobs:
   format_code:


### PR DESCRIPTION
Not sure this will work as intended, but here to revert if needed. 

This makes the auto-formatter run when code is merged into main, as before. It does it from a personal access token from a bot account that should have access to push to main (including special permission to skip PRs). There's also some extra logic to avoid infinite loops, as using GITHUB_TOKEN has special handling to avoid loops that using a PAT avoids