### PR TITLE
Fixed errors for Ball Mario

### DIFF
--- a/scenes/Player.tscn
+++ b/scenes/Player.tscn
@@ -136,3 +136,4 @@ flip_h = true
 visible = false
 position = Vector2( 6.75, 11.1875 )
 shape = SubResource( 13 )
+disabled = true

--- a/scripts/BallPlayer.gd
+++ b/scripts/BallPlayer.gd
@@ -36,7 +36,7 @@ func _physics_process(_delta: float) -> void:
 		max_speed_modifier = 1.5
 		acceleration_modifier = 3
 		animationSpeed = 60
-	sprite.frames.set_animation_speed("run", animationSpeed)
+	#sprite.frames.set_animation_speed("run", animationSpeed)
 
 	if Input.is_action_pressed("right"):
 		motion.x += ACCEL * acceleration_modifier
@@ -54,7 +54,7 @@ func _physics_process(_delta: float) -> void:
 		
 		"""
 	else:
-		sprite.play("idle")
+		#sprite.play("idle")
 		motion.x = lerp(motion.x, 0, 0.05)
 
 	if Input.is_action_pressed("up"):

--- a/scripts/Player.gd
+++ b/scripts/Player.gd
@@ -323,7 +323,7 @@ func _on_bus_collected(data):
 	if data.has("collected"):
 		isBus = data["collected"]
 		$BusSprite.visible = true
-		$BusCollision.visible = true
+		$BusCollision.set_deferred("disabled", false)
 		sprite.visible = false
-		$CollisionShape2D.visible = false
+		$CollisionShape2D.set_deferred("disabled", true)
 		trail.height = 15


### PR DESCRIPTION
I'll note that the fix is not very elegant. BallPlayer.gd is mostly code copied from Player.gd, when it should just extend Player.gd. Also, the code for animations is commented out, which doesn't look good, but it will make it easier to add animations for Ball Mario in the future. Also fixes Player collision issue described in #200 (I forgot to change branch, otherwise it would have been separate).