### PR TITLE
Handle non-successful response codes in GitHubAPI.gd

### DIFF
--- a/autoload/GitHubAPI.gd
+++ b/autoload/GitHubAPI.gd
@@ -9,8 +9,8 @@ signal contributors_loaded(names)
 func _ready():
 	# Don't call the github api while testing in the editor
 	# because we don't need it.
-	if OS.has_feature("editor"):
-		return
+#	if OS.has_feature("editor"):
+#		return
 	
 	var http_request = HTTPRequest.new()
 	add_child(http_request)
@@ -24,6 +24,16 @@ func _ready():
 
 func _on_request_completed(result, _response_code, _headers, body):
 	if result != HTTPRequest.RESULT_SUCCESS:
+		return
+	if _response_code != 200:
+		print()
+		print("ERROR: Got response code {code} while trying to get github contributors".format({
+			"code": _response_code
+		}))
+		print("   BODY: {body}".format({
+			"body": JSON.parse(body.get_string_from_utf8()).result
+		}))
+		print()
 		return
 
 	var json = JSON.parse(body.get_string_from_utf8())

--- a/autoload/GitHubAPI.gd
+++ b/autoload/GitHubAPI.gd
@@ -7,6 +7,11 @@ signal contributors_loaded(names)
 
 
 func _ready():
+	# Don't call the github api while testing in the editor
+	# because we don't need it.
+	if OS.has_feature("editor"):
+		return
+	
 	var http_request = HTTPRequest.new()
 	add_child(http_request)
 	http_request.connect("request_completed", self, "_on_request_completed")


### PR DESCRIPTION
Fixes #205.

This change will
1. Handle unsuccessful commits
2. Prevent GitHub API request while in the editor