### PR TITLE
move ddr music track to music bus

### DIFF
--- a/scenes/levels/DDR_01/Level.tscn
+++ b/scenes/levels/DDR_01/Level.tscn
@@ -51,6 +51,7 @@ position = Vector2( 0, 702.243 )
 [node name="Audio" type="AudioStreamPlayer" parent="."]
 stream = ExtResource( 7 )
 autoplay = true
+bus = "music"
 
 [connection signal="set_tick" from="." to="LeftTrack" method="_on_Level_set_tick"]
 [connection signal="set_tick" from="." to="RightTrack" method="_on_Level_set_tick"]


### PR DESCRIPTION
this might actually be controversial, considering the ddr music is more important to the rhythm gameplay of that level than some of the other types of level we have so far, so tweaking how it's played is something that could have unintended side effects
could see the case where, because you currently can't change audio settings while in the ddr level, you might load in with old settings that have music reduced or muted, and then not be able to change that to hear the music. maybe bad?

but with that said, moved the song's audiostream from the master -> music bus