### PR TITLE
Compartmentalize player logic into smaller chunks

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -163,9 +163,9 @@ _global_script_class_icons={
 "Powerup": "",
 "ScreenShake": "",
 "ShakingCamera": "",
-"TrackParser": "",
 "SokobanLevel": "res://sprites/box.png",
-"SpawnPoint": ""
+"SpawnPoint": "",
+"TrackParser": ""
 }
 
 [application]

--- a/scenes/Player.tscn
+++ b/scenes/Player.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=21 format=2]
+[gd_scene load_steps=25 format=2]
 
 [ext_resource path="res://sfx/jump.wav" type="AudioStream" id=1]
 [ext_resource path="res://sprites/mario.png" type="Texture" id=2]
@@ -7,6 +7,10 @@
 [ext_resource path="res://sprites/flag.jpg" type="Texture" id=5]
 [ext_resource path="res://sprites/dustparticle.png" type="Texture" id=6]
 [ext_resource path="res://sprites/bus.png" type="Texture" id=7]
+[ext_resource path="res://scripts/mariocontroller/Shooter.gd" type="Script" id=8]
+[ext_resource path="res://scripts/mariocontroller/CoinCollector.gd" type="Script" id=9]
+[ext_resource path="res://scripts/mariocontroller/BlockBuilder.gd" type="Script" id=10]
+[ext_resource path="res://scripts/mariocontroller/Bus.gd" type="Script" id=11]
 
 [sub_resource type="Curve" id=11]
 _data = [ Vector2( 0, 0 ), 0.0, 2.49311, 0, 0, Vector2( 1, 1 ), 0.329092, 0.0, 0, 0 ]
@@ -100,6 +104,7 @@ offset = Vector2( 0, -16 )
 
 [node name="ShootOrigin" type="Position2D" parent="Sprite"]
 position = Vector2( 4, -16 )
+script = ExtResource( 8 )
 
 [node name="JumpSFX" type="AudioStreamPlayer2D" parent="."]
 stream = ExtResource( 1 )
@@ -124,6 +129,15 @@ angle = 90.0
 angle_random = 1.0
 scale_amount = 0.75
 color = Color( 1, 1, 1, 0.784314 )
+
+[node name="CoinCollector" type="Node" parent="."]
+script = ExtResource( 9 )
+
+[node name="BlockBuilder" type="Node" parent="."]
+script = ExtResource( 10 )
+
+[node name="Bus" type="Node" parent="."]
+script = ExtResource( 11 )
 
 [node name="BusSprite" type="Sprite" parent="."]
 visible = false

--- a/scripts/mariocontroller/BlockBuilder.gd
+++ b/scripts/mariocontroller/BlockBuilder.gd
@@ -1,0 +1,6 @@
+extends Node
+
+
+func _input(event: InputEvent) -> void:
+	if event.is_action_pressed("Build"):
+		EventBus.emit_signal("build_block", {"player": owner})

--- a/scripts/mariocontroller/Bus.gd
+++ b/scripts/mariocontroller/Bus.gd
@@ -1,0 +1,30 @@
+extends Node
+
+
+onready var player : Player = owner
+onready var sprite : Sprite = player.get_node("BusSprite")
+onready var collision : CollisionShape2D = player.get_node("BusCollision")
+
+var isBus : bool = false
+
+
+func _ready() -> void:
+	EventBus.connect("bus_collected", self, "_on_bus_collected")
+	set_process(false)
+
+
+func _process(_delta: float) -> void:
+	sprite.flip_h = !player.sprite.flip_h
+
+
+func _on_bus_collected(data: Dictionary) -> void:
+	if data.has("collected"):
+		isBus = data["collected"]
+		sprite.visible = true
+		collision.set_deferred("disabled", false)
+		
+		set_process(true)
+
+		player.sprite.visible = false
+		player.get_node("CollisionShape2D").set_deferred("disabled", true)
+		player.trail.height = 15

--- a/scripts/mariocontroller/CoinCollector.gd
+++ b/scripts/mariocontroller/CoinCollector.gd
@@ -1,0 +1,15 @@
+extends Node
+
+
+onready var player : Player = owner
+
+
+func _ready() -> void:
+	EventBus.connect("coin_collected", self, "_on_coin_collected")
+
+
+func _on_coin_collected(data: Dictionary) -> void:
+	var value := 1
+	if data.has("value"):
+		value = data["value"]
+	player.coins += value

--- a/scripts/mariocontroller/Shooter.gd
+++ b/scripts/mariocontroller/Shooter.gd
@@ -1,0 +1,46 @@
+extends Position2D
+
+
+export(PackedScene) var default_projectile: PackedScene = preload("res://scenes/CoinProjectile.tscn")
+export(PackedScene) var fireball_projectile: PackedScene = preload("res://scenes/powerups/Fireball.tscn")
+
+onready var player : Player = owner
+
+var hasFlower : bool = false
+
+
+func _ready() -> void:
+	EventBus.connect("fire_flower_collected", self, "_on_flower_collected")
+
+
+func _input(event: InputEvent) -> void:
+	# Remove one coin and spawn a projectile
+	# Continus shooting after 0 coins
+	if event.is_action_pressed("shoot") and player.coins > 0:
+		EventBus.emit_signal("coin_collected", {"value": -1, "type": "gold"})
+		shoot(default_projectile)
+	#Shoots fireball
+	if event.is_action_pressed("fire") and hasFlower:
+		shoot(fireball_projectile)
+
+
+func shoot(projectile_scene: PackedScene) -> void:
+	# Spawn the projectile and move it to its origin point
+	# Origin is affected by changes to Sprite (ex: squashing)
+	var projectile = projectile_scene.instance()
+	player.get_parent().add_child(projectile)
+	var shoot_dir := Vector2.LEFT if player.sprite.flip_h else Vector2.RIGHT
+	# Changes ShootOrigin based on direction
+	if shoot_dir == Vector2.LEFT:
+		set_position(Vector2(-4, -16))
+	else:
+		set_position(Vector2(4, -16))
+	projectile.position = global_position
+	# Projectile handles movement
+	projectile.start_moving(shoot_dir)
+	player.emit_signal("shooting")
+
+
+func _on_flower_collected(data : Dictionary) -> void:
+	if data.has("collected"):
+		hasFlower = data["collected"]


### PR DESCRIPTION
A small example of how we can easily compartmentalize behaviours into self-contained (or almost self-contained) chunks of logic.  
Nothing should change gameplay-wise, and I haven't rewritten anything*, only moved code around.  

\* This is almost true, the only thing I rewrote is how the bus sprite is flipped.