### PR TITLE
Camera Follow on Hub ❤️ 

### DIFF
--- a/scenes/levels/CameraFollow.gd
+++ b/scenes/levels/CameraFollow.gd
@@ -1,0 +1,11 @@
+extends Position2D
+onready var camera_reference: Camera2D  = $"../../Camera"
+onready var player_reference: Player  = $"../Player"
+
+func _process(_delta):
+
+	if(not player_reference):
+		player_reference = $"../Player"
+	if(camera_reference and player_reference):
+		camera_reference.position.x = player_reference.position.x
+	pass

--- a/scenes/levels/Hub.tscn
+++ b/scenes/levels/Hub.tscn
@@ -1,8 +1,9 @@
-[gd_scene load_steps=5 format=2]
+[gd_scene load_steps=6 format=2]
 
 [ext_resource path="res://scenes/levels/TileSet.tres" type="TileSet" id=1]
 [ext_resource path="res://scenes/SpawnPoint.tscn" type="PackedScene" id=2]
 [ext_resource path="res://scenes/EndPortal.tscn" type="PackedScene" id=3]
+[ext_resource path="res://scenes/levels/CameraFollow.gd" type="Script" id=4]
 [ext_resource path="res://scripts/levels/Hub.gd" type="Script" id=6]
 
 [node name="TileMap" type="TileMap"]
@@ -16,3 +17,6 @@ portal_scene = ExtResource( 3 )
 
 [node name="SpawnPoint" parent="." instance=ExtResource( 2 )]
 position = Vector2( 160, 480 )
+
+[node name="CameraFollow" type="Position2D" parent="."]
+script = ExtResource( 4 )

--- a/scripts/Camera.gd
+++ b/scripts/Camera.gd
@@ -8,6 +8,7 @@ const CameraLeanAmount = preload("res://scripts/CameraLeanAmount.gd")
 func _ready():
 	EventBus.connect("jumping", self, "trigger_small_shake")
 	EventBus.connect("enemy_killed", self, "trigger_small_shake")
+	EventBus.connect("level_started", self, "return_to_center")
 	position = get_viewport_rect().size / 2
 
 
@@ -46,3 +47,6 @@ func trigger_medium_shake() -> void:
 
 func trigger_large_shake() -> void:
 	_screen_shake.start(.1, 20, 50, 10)
+
+func return_to_center(_data) -> void:
+	position = get_viewport_rect().size / 2


### PR DESCRIPTION
Finally we can see the whole Hub.

This is really just a kind of quick fix so we can see the whole hub of levels and enter them. 
You can add CameraFollow to your level to make the camera follow mario. But I didn't test that much.

For now I just want everyone to have access to all hub levels.

Thanks for reading :D