### PR TITLE
Using resource for player coins

### DIFF
--- a/autoload/EventBus.gd
+++ b/autoload/EventBus.gd
@@ -9,6 +9,9 @@ signal build_block(data)
 signal level_completed(data)
 signal level_started(data)
 
+# called once on game start
+signal initial_startup()
+
 # Scene Transitions, expects "scene" key
 signal change_scene(data)
 

--- a/scripts/Main.gd
+++ b/scripts/Main.gd
@@ -19,7 +19,12 @@ func _ready() -> void:
 	Settings.load_data()
 	_hook_portals()
 	VisualServer.set_default_clear_color(Color.black)
+	
+	# make sure all scripts are ready to receive the signal
+	call_deferred("_final_ready")
 
+func _final_ready() -> void:
+	EventBus.emit_signal("initial_startup")
 
 func _hook_portals() -> void:
 	for portal in get_tree().get_nodes_in_group(ENDPORTALS_GROUP):

--- a/scripts/Player.gd
+++ b/scripts/Player.gd
@@ -16,6 +16,7 @@ const JUMP_BUFFER_TIME = 0.05
 const SLIP_RANGE = 16
 
 var gravity = preload("res://scripts/resources/Gravity.tres")
+var inventory = preload("res://scripts/resources/PlayerInventory.tres")
 
 var coyote_timer = COYOTE_TIME  # used to give a bit of extra-time to jump after leaving the ground
 var jump_buffer_timer = 0  # gives a bit of buffer to hit the jump button before landing
@@ -26,7 +27,6 @@ var double_jump = true
 var crouching = false
 var grounded = false
 var anticipating_jump = false  # the small window of time before the player jumps
-var coins = 0  #grabbed directly from the coin_collected signal;
 var hearts = 3
 
 # STATS BLOCK
@@ -52,6 +52,7 @@ onready var stretch_scale = Vector2(original_scale.x * 0.4, original_scale.y * 1
 
 
 func _ready() -> void:
+	EventBus.connect("initial_startup", self, "_on_initial_startup")
 	EventBus.connect("heart_changed", self, "_on_heart_change")
 	hearts = get_node("../../UI/UI/HeartCount").count
 	EventBus.connect("enemy_hit_coin", self, "_on_enemy_hit_coin")
@@ -295,6 +296,8 @@ func _is_on_floor() -> bool:
 		or (gravity.direction.y == Vector2.UP.y and is_on_ceiling())
 	)
 
+func _on_initial_startup() -> void:
+	inventory.reset()
 
 func _on_heart_change(data):
 	var value := 1

--- a/scripts/mariocontroller/CoinCollector.gd
+++ b/scripts/mariocontroller/CoinCollector.gd
@@ -11,3 +11,6 @@ func _on_coin_collected(data: Dictionary) -> void:
 	if data.has("value"):
 		value = data["value"]
 	player.inventory.coins += value
+
+func _exit_tree():
+	EventBus.disconnect("coin_collected", self, "_on_coin_collected")

--- a/scripts/mariocontroller/CoinCollector.gd
+++ b/scripts/mariocontroller/CoinCollector.gd
@@ -1,8 +1,6 @@
 extends Node
 
-
 onready var player : Player = owner
-
 
 func _ready() -> void:
 	EventBus.connect("coin_collected", self, "_on_coin_collected")
@@ -12,4 +10,4 @@ func _on_coin_collected(data: Dictionary) -> void:
 	var value := 1
 	if data.has("value"):
 		value = data["value"]
-	player.coins += value
+	player.inventory.coins += value

--- a/scripts/mariocontroller/Shooter.gd
+++ b/scripts/mariocontroller/Shooter.gd
@@ -16,7 +16,7 @@ func _ready() -> void:
 func _input(event: InputEvent) -> void:
 	# Remove one coin and spawn a projectile
 	# Continus shooting after 0 coins
-	if event.is_action_pressed("shoot") and player.coins > 0:
+	if event.is_action_pressed("shoot") and player.inventory.coins > 0:
 		EventBus.emit_signal("coin_collected", {"value": -1, "type": "gold"})
 		shoot(default_projectile)
 	#Shoots fireball

--- a/scripts/resources/PlayerInventory.gd
+++ b/scripts/resources/PlayerInventory.gd
@@ -1,0 +1,11 @@
+# hold player information across scenes
+# has to be reset on game restart
+extends Resource
+
+export var coins: int
+
+func _init() -> void:
+	reset()
+
+func reset() -> void:
+    coins = 0

--- a/scripts/resources/PlayerInventory.tres
+++ b/scripts/resources/PlayerInventory.tres
@@ -1,0 +1,7 @@
+[gd_resource type="Resource" load_steps=2 format=2]
+
+[ext_resource path="res://scripts/resources/PlayerInventory.gd" type="Script" id=1]
+
+[resource]
+script = ExtResource( 1 )
+coins = 0

--- a/ui/CoinCount.gd
+++ b/ui/CoinCount.gd
@@ -1,20 +1,14 @@
 extends RichTextLabel
 
-var count := 0
-
+var inventory = preload("res://scripts/resources/PlayerInventory.tres")
 
 func _ready():
 	EventBus.connect("coin_collected", self, "_on_coin_collected")
 	update_coin_count()
 
-
-func _on_coin_collected(data):
-	var value := 1
-	if data.has("value"):
-		value = data["value"]
-	count += value
-	update_coin_count()
+func _on_coin_collected(_data):
+	call_deferred("update_coin_count")
 
 
 func update_coin_count():
-	bbcode_text = tr("UI_COINS") % count
+	bbcode_text = tr("UI_COINS") % inventory.coins


### PR DESCRIPTION
New idea as follow-up to #180

Using a resource to hold player values across scenes. Has to be reset when the game restarts, so added a signal for that.

It could also be shared with other classes (see CoinCount.gd) in order to have a single point of truth. Drawback here however is that the change signal might be received before the resource is updated. So we have to use a deferred call to ensure the correct order.

Can later be extended for hearts, flowers, etc. Let me know what you think!