### PR TITLE
CameraFollow as a Scene, you can follow on any axis, and it follows smoooooothly 🎥 

### DIFF
--- a/scenes/CameraFollow.tscn
+++ b/scenes/CameraFollow.tscn
@@ -1,0 +1,6 @@
+[gd_scene load_steps=2 format=2]
+
+[ext_resource path="res://scenes/levels/CameraFollow.gd" type="Script" id=1]
+
+[node name="CameraFollow" type="Position2D"]
+script = ExtResource( 1 )

--- a/scenes/levels/CameraFollow.gd
+++ b/scenes/levels/CameraFollow.gd
@@ -1,11 +1,20 @@
 extends Position2D
 onready var camera_reference: Camera2D  = $"../../Camera"
 onready var player_reference: Player  = $"../Player"
+export var follow_horizontally: bool = true
+export var follow_vertically: bool = false
+export(float,0,1) var follow_speed: float = 0.1
 
 func _process(_delta):
-
+	
 	if(not player_reference):
+		print("not player")
 		player_reference = $"../Player"
+
 	if(camera_reference and player_reference):
-		camera_reference.position.x = player_reference.position.x
+		if(follow_horizontally):
+			camera_reference.position.x = lerp(camera_reference.position.x, player_reference.position.x, follow_speed)
+		if(follow_vertically):
+			camera_reference.position.y = lerp(camera_reference.position.y, player_reference.position.y, follow_speed)
+	
 	pass

--- a/scenes/levels/Hub.tscn
+++ b/scenes/levels/Hub.tscn
@@ -3,7 +3,7 @@
 [ext_resource path="res://scenes/levels/TileSet.tres" type="TileSet" id=1]
 [ext_resource path="res://scenes/SpawnPoint.tscn" type="PackedScene" id=2]
 [ext_resource path="res://scenes/EndPortal.tscn" type="PackedScene" id=3]
-[ext_resource path="res://scenes/levels/CameraFollow.gd" type="Script" id=4]
+[ext_resource path="res://scenes/CameraFollow.tscn" type="PackedScene" id=4]
 [ext_resource path="res://scripts/levels/Hub.gd" type="Script" id=6]
 
 [node name="TileMap" type="TileMap"]
@@ -18,5 +18,4 @@ portal_scene = ExtResource( 3 )
 [node name="SpawnPoint" parent="." instance=ExtResource( 2 )]
 position = Vector2( 160, 480 )
 
-[node name="CameraFollow" type="Position2D" parent="."]
-script = ExtResource( 4 )
+[node name="CameraFollow" parent="." instance=ExtResource( 4 )]


### PR DESCRIPTION
Added a CameraFollow scene, just add it to your scene and camera will follow mario

You can choose from the inspector which axis to follow, horizontally, vertically or both. 
Camera follows smoothly using lerp so you can move the speed slider to make the camera follow slower or faster on that level.

Go bananas with level creation. 🎥 ❤️ 

Known Issues : when you go back to hub after ending a bunch of levels, camera doesn't follow mario on that hub instance. I'll do a fix when I have more time, but in the meantime I'm releasing this so people can use it on their levels