### PR TITLE
Prevent autoformatter builds from triggering deploy

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -39,7 +39,7 @@ jobs:
 
   build_game:
     name: Build Game
-    if: ${{ github.event.label.name != 'skip release' }}
+    if: ${{ github.event.label.name != 'skip release' || !contains(github.event.head_commit.message, 'Auto-Format GDScript') }}
     runs-on: ubuntu-latest
     steps:
       - name: checkout latest code


### PR DESCRIPTION
Does what it says on the box. I was safeguarding against autoformatter commits from causing an infinite loop, but didn't stop them from triggering the build/deploy process.