### PR TITLE
Fixed camera on returning to hub 🎥 ✅ 

### DIFF
--- a/scenes/levels/CameraFollow.gd
+++ b/scenes/levels/CameraFollow.gd
@@ -7,8 +7,7 @@ export(float,0,1) var follow_speed: float = 0.1
 
 func _process(_delta):
 	
-	if(not player_reference):
-		print("not player")
+	if(not player_reference or not player_reference.is_inside_tree()):
 		player_reference = $"../Player"
 
 	if(camera_reference and player_reference):


### PR DESCRIPTION
So it seems that there was a player orphan when re entering the hub so I just check now if it's an orphan node, and if it is, search for the not-orphan-mario. I don't know if there is a memory leak problem somewhere of lots of orphan marios everytime you go back to the hub. But that seems like a bug fix for another day 😆 