### PR TITLE
Change player's speed with bus powerup (2)

### DIFF
--- a/scripts/Player.gd
+++ b/scripts/Player.gd
@@ -40,6 +40,8 @@ var swim = 0
 var acrobatics = 0
 var building = 1
 var sanity = 10
+var powerupspeed = 1
+var powerupaccel = 1
 
 onready var sprite = $Sprite
 onready var tween = $Tween
@@ -66,6 +68,9 @@ func _physics_process(delta: float) -> void:
 	x_motion.max_accel = MAXACCEL
 	y_motion.set_axis(gravity.direction)
 	y_motion.max_accel = gravity.strength
+
+	x_motion.max_speed *= powerupspeed
+	x_motion.max_accel *= powerupaccel
 
 	var jerk_modifier = 1
 	var animationSpeed = 8

--- a/scripts/mariocontroller/Bus.gd
+++ b/scripts/mariocontroller/Bus.gd
@@ -15,6 +15,12 @@ func _ready() -> void:
 
 func _process(_delta: float) -> void:
 	sprite.flip_h = !player.sprite.flip_h
+	if isBus:
+		player.powerupspeed = 4
+		player.powerupaccel = 2
+	else:
+		player.powerupspeed = 1
+		player.powerupaccel = 1
 
 
 func _on_bus_collected(data: Dictionary) -> void:


### PR DESCRIPTION
This do the same thing as my previous pull request ( #211  ).

Video :

https://user-images.githubusercontent.com/46846090/163167986-8850b189-ed4c-473d-8dc6-3f467d57be01.mp4

(I did not commit the modification of adding the bus powerup in the hub in this PR)
