### PR TITLE
Keep powerups through levels

### DIFF
--- a/scenes/ui/HeartCount.gd
+++ b/scenes/ui/HeartCount.gd
@@ -1,19 +1,17 @@
 extends RichTextLabel
 
-var count := 3
+var inventory = preload("res://scripts/resources/PlayerInventory.tres")
 
-
-func _ready():
+func _ready() -> void:
 	EventBus.connect("heart_changed", self, "_on_heart_change")
+	_update_hearts()
 
+func _on_heart_change(_data: Dictionary) -> void:
+	call_deferred("_update_hearts")
+	
 
-func _on_heart_change(data):
-	var value := 1
-	if data.has("value"):
-		value = data["value"]
-
-	count += value
+func _update_hearts() -> void:
 	bbcode_text = (
 		"\n[wave amp=50 freq=2]HEARTS:[rainbow freq=0.5 sat=1 val=20]%d[/rainbow][/wave]"
-		% count
+		% inventory.hearts
 	)

--- a/scripts/Main.gd
+++ b/scripts/Main.gd
@@ -20,12 +20,9 @@ func _ready() -> void:
 	_hook_portals()
 	VisualServer.set_default_clear_color(Color.black)
 
-	# make sure all scripts are ready to receive the signal
-	call_deferred("_final_ready")
 
-
-func _final_ready() -> void:
-	EventBus.emit_signal("initial_startup")
+func _exit_tree() -> void:
+	EventBus.emit_signal("game_exit")
 
 
 func _hook_portals() -> void:

--- a/scripts/Player.gd
+++ b/scripts/Player.gd
@@ -306,10 +306,6 @@ func _is_on_floor() -> bool:
 	)
 
 
-func _on_initial_startup() -> void:
-	inventory.reset()
-
-
 func _on_heart_change(data):
 	var value := 1
 	if data.has("value"):

--- a/scripts/autoload/EventBus.gd
+++ b/scripts/autoload/EventBus.gd
@@ -9,14 +9,13 @@ signal build_block(data)
 signal level_completed(data)
 signal level_started(data)
 
-# called once on game start
-signal initial_startup
-
 # Scene Transitions, expects "scene" key
 signal change_scene(data)
 
 # pauses the game - used by PauseMenu.gd
 signal game_paused(data)
+# called once on game ends (or is restarted)
+signal game_exit
 
 ## settings signals
 # toggles crt filter - emitted by PauseMenu.gd and connected to Main.gd

--- a/scripts/mariocontroller/Bus.gd
+++ b/scripts/mariocontroller/Bus.gd
@@ -5,12 +5,12 @@ onready var player : Player = owner
 onready var sprite : Sprite = player.get_node("BusSprite")
 onready var collision : CollisionShape2D = player.get_node("BusCollision")
 
-var isBus : bool = false
-
-
 func _ready() -> void:
 	EventBus.connect("bus_collected", self, "_on_bus_collected")
-	set_process(false)
+	if player.inventory.has_bus:
+		_activate_bus()
+	else:
+		set_process(false)
 
 
 func _process(_delta: float) -> void:
@@ -19,12 +19,18 @@ func _process(_delta: float) -> void:
 
 func _on_bus_collected(data: Dictionary) -> void:
 	if data.has("collected"):
-		isBus = data["collected"]
-		sprite.visible = true
-		collision.set_deferred("disabled", false)
-		
-		set_process(true)
+		player.inventory.has_bus = data["collected"]
+		_activate_bus()
 
-		player.sprite.visible = false
-		player.get_node("CollisionShape2D").set_deferred("disabled", true)
-		player.trail.height = 15
+
+func _activate_bus() -> void:
+	sprite.visible = true
+	collision.set_deferred("disabled", false)
+	call_deferred("_update_player")
+	set_process(true)
+
+
+func _update_player() -> void:
+	player.sprite.visible = false
+	player.get_node("CollisionShape2D").set_deferred("disabled", true)
+	player.trail.height = 15

--- a/scripts/mariocontroller/Shooter.gd
+++ b/scripts/mariocontroller/Shooter.gd
@@ -6,9 +6,6 @@ export(PackedScene) var fireball_projectile: PackedScene = preload("res://scenes
 
 onready var player : Player = owner
 
-var hasFlower : bool = false
-
-
 func _ready() -> void:
 	EventBus.connect("fire_flower_collected", self, "_on_flower_collected")
 
@@ -20,7 +17,7 @@ func _input(event: InputEvent) -> void:
 		EventBus.emit_signal("coin_collected", {"value": -1, "type": "gold"})
 		shoot(default_projectile)
 	#Shoots fireball
-	if event.is_action_pressed("fire") and hasFlower:
+	if event.is_action_pressed("fire") and player.inventory.has_flower:
 		shoot(fireball_projectile)
 
 
@@ -43,4 +40,4 @@ func shoot(projectile_scene: PackedScene) -> void:
 
 func _on_flower_collected(data : Dictionary) -> void:
 	if data.has("collected"):
-		hasFlower = data["collected"]
+		player.inventory.has_flower = data["collected"]

--- a/scripts/resources/PlayerInventory.gd
+++ b/scripts/resources/PlayerInventory.gd
@@ -3,9 +3,12 @@
 extends Resource
 
 export var coins: int
-
-func _init() -> void:
-	reset()
+export var hearts: int
+export var has_flower: bool
+export var has_bus: bool
 
 func reset() -> void:
-    coins = 0
+	coins = 0
+	hearts = 3
+	has_flower = false
+	has_bus = false

--- a/scripts/resources/PlayerInventory.tres
+++ b/scripts/resources/PlayerInventory.tres
@@ -5,3 +5,6 @@
 [resource]
 script = ExtResource( 1 )
 coins = 0
+hearts = 3
+has_flower = false
+has_bus = false


### PR DESCRIPTION
Fixes #164.

Hearts, Bus and Flower are now part of the inventory and are kept between levels.
I've changed a bit how the inventory is reset. Instead of early on startup (which would mess up the ui), it's when the main game container exits the tree (e.g. on restart).