### PR TITLE
Disable CRT filter and Camera lean by default

### DIFF
--- a/scenes/ui/PauseMenu.tscn
+++ b/scenes/ui/PauseMenu.tscn
@@ -89,9 +89,6 @@ bbcode_enabled = true
 text = "
 GRAPHICS SETTINGS
 "
-__meta__ = {
-"_edit_use_anchors_": false
-}
 
 [node name="SFXLabel" type="RichTextLabel" parent="PauseMenu/MainMenu"]
 anchor_left = 0.428
@@ -181,7 +178,7 @@ rect_scale = Vector2( 2, 2 )
 custom_fonts/normal_font = SubResource( 1 )
 bbcode_enabled = true
 text = "
-CAMERA LEAN: <  MAX  >
+CAMERA LEAN: <  OFF  >
 "
 __meta__ = {
 "_edit_use_anchors_": false

--- a/scenes/ui/PauseMenu.tscn
+++ b/scenes/ui/PauseMenu.tscn
@@ -213,7 +213,7 @@ rect_scale = Vector2( 2, 2 )
 custom_fonts/normal_font = SubResource( 1 )
 bbcode_enabled = true
 text = "
-CRT FILTER: ON
+CRT FILTER: OFF
 "
 
 [node name="SFXMenu" type="Control" parent="PauseMenu"]

--- a/scripts/autoload/Settings.gd
+++ b/scripts/autoload/Settings.gd
@@ -48,28 +48,29 @@ func load_data():
 		volume_game = 10
 		volume_music = 10
 		volume_sfx = 10
-		return
 
 	# access settings.mario and read settings
-	settings_file.open(settings_name, File.READ)
-	while settings_file.get_position() < settings_file.get_len():
-		var settings_values = parse_json(settings_file.get_line())
-		for i in settings_values.keys():
-			match i:
-				"gfx_camera_lean":
-					camera_lean = int(settings_values[i])
-				"gfx_screen_shake":
-					screen_shake = bool(settings_values[i])
-				"gfx_crt_filter":
-					crt_filter = bool(settings_values[i])
-				"sfx_volume_game":
-					volume_game = int(settings_values[i])
-				"sfx_volume_music":
-					volume_music = int(settings_values[i])
-				"sfx_volume_sfx":
-					volume_sfx = int(settings_values[i])
-	settings_file.close()
-	settings_loaded = true
+	else:
+		settings_file.open(settings_name, File.READ)
+		while settings_file.get_position() < settings_file.get_len():
+			var settings_values = parse_json(settings_file.get_line())
+			for i in settings_values.keys():
+				match i:
+					"gfx_camera_lean":
+						camera_lean = int(settings_values[i])
+					"gfx_screen_shake":
+						screen_shake = bool(settings_values[i])
+					"gfx_crt_filter":
+						crt_filter = bool(settings_values[i])
+					"sfx_volume_game":
+						volume_game = int(settings_values[i])
+					"sfx_volume_music":
+						volume_music = int(settings_values[i])
+					"sfx_volume_sfx":
+						volume_sfx = int(settings_values[i])
+			settings_file.close()
+			settings_loaded = true
+	
 
 	# emit any relevant signals
 	EventBus.emit_signal("crt_filter_toggle", crt_filter)

--- a/scripts/autoload/Settings.gd
+++ b/scripts/autoload/Settings.gd
@@ -41,9 +41,9 @@ func load_data():
 	# there is no settings.mario :(
 	if not settings_file.file_exists(settings_name):
 		# set settings to default values
-		camera_lean = CameraLeanAmount.MAX
+		camera_lean = CameraLeanAmount.OFF
 		screen_shake = true
-		crt_filter = true
+		crt_filter = false
 
 		volume_game = 10
 		volume_music = 10


### PR DESCRIPTION
(for players with no settings file). I love the effects, but they're a bit disruptive to be on by default.

I'mma need to test in the netlify build to confirm this works.