### PR TITLE
Rework localization workflow

### DIFF
--- a/localization/loca.csv
+++ b/localization/loca.csv
@@ -1,27 +1,48 @@
-"keys","en","de"
-"TRANSLATE_ME","TRANSLATE ME!","ÜBERSETZE MICH!"
-"TUTORIAL_MOVEMENT","ARROW KEYS TO [rainbow freq=0.5 sat=1 val=20]MOVE[/rainbow]
+"keys","de"
+"TRANSLATE ME!","ÜBERSETZE MICH!"
+"ARROW KEYS TO [rainbow freq=0.5 sat=1 val=20]MOVE[/rainbow]
+
 SHIFT TO [wave amp=50 freq=2]SPRINT[/wave]
+
 SPACE TO [wave amp=50 freq=2]JUMP[/wave]
-X2 SPACE TO [wave amp=50 freq=2]DOUBLE JUMP[/wave]
+
 CONTROL/Z TO [wave amp=50 freq=2]SHOOT[/wave]
-B TO[wave amp=50 freq=2] FIREBALL [/wave] (WITH POWERUP)","PFEILTASTEN ZUM [rainbow freq=0.5 sat=1 val=20]BEWEGEN[/rainbow]
-UMSCHALT ZUM [wave amp=50 freq=2]SPRINTEN[/wave]
+
+B TO[wave amp=50 freq=2] FIREBALL [/wave]
+
+(WITH POWERUP)", "UMSCHALT ZUM [wave amp=50 freq=2]SPRINTEN[/wave]
+
 LEERTASTE ZUM [wave amp=50 freq=2]SPRINGEN[/wave]
+
 2X LEERTASTE FUER [wave amp=50 freq=2]DOPPELSPRUNG[/wave]
+
 STRG/Z ZUM [wave amp=50 freq=2]SCHIESSEN[/wave]
+
 B FUER DEN[wave amp=50 freq=2] FEUERBALL [/wave] (MIT POWERUP)"
-"UI_COINS","
+"
 [wave amp=50 freq=2]COINS:[rainbow freq=0.5 sat=1 val=20]%d[/rainbow] [/wave]","
 [wave amp=50 freq=2]MUENZEN:[rainbow freq=0.5 sat=1 val=20]%d[/rainbow] [/wave]"
-"CREDITS_TITLE","CREDITS","CREDITS"
-"UI_LEVEL"," [wave amp=50 freq=2]LEVEL:[rainbow freq=0.5 sat=1 val=20]%d[/rainbow] [/wave]"," [wave amp=50 freq=2]LEVEL:[rainbow freq=0.5 sat=1 val=20]%d[/rainbow] [/wave]"
-"PLAYER_DIED"," [wave amp=50 freq=2][rainbow freq=0.5 sat=1 val=20]YOU DIED[/rainbow] [/wave]"," [wave amp=50 freq=2][rainbow freq=0.5 sat=1 val=20]YOU DIED[/rainbow] [/wave]"
-"STARCOLLECT"," [wave amp=50 freq=2]YOU GOT THE STAR:\n[rainbow freq=0.5 sat=1 val=20]%s[/rainbow] [/wave]"," [wave amp=50 freq=2]DU HAST DEN STERN:\n[rainbow freq=0.5 sat=1 val=20]%s[/rainbow] [/wave]"
-"STARCOLLECTAGAIN"," [wave amp=50 freq=2]YOU ALREADY HAVE:\n[rainbow freq=0.5 sat=1 val=20]%s[/rainbow] [/wave]"," [wave amp=50 freq=2]DU HAST SCHON:\n[rainbow freq=0.5 sat=1 val=20]%s[/rainbow] [/wave]"
-"ACHIEVEMENT_UNLOCKED","ACHIEVEMENT UNLOCKED: %s","ERRUNGENSCHAFT FREIGESCHALTET: %s"
-"ACHIEVEMENT_COINS_LEVEL0","GET ALL THE COINS IN LEVEL 0","SAMMLE ALLE MUENZEN IN LEVEL 0"
-"ACHIEVEMENT_COINS_LEVEL1","GET ALL THE COINS IN LEVEL 1","SAMMLE ALLE MUENZEN IN LEVEL 1"
-"ACHIEVEMENT_COINS_LEVEL2","GET ALL THE COINS IN LEVEL 2","SAMMLE ALLE MUENZEN IN LEVEL 2"
-"TUTORIAL_MOVEMENT_PLANE", "SPACE TO [rainbow freq=0.5 sat=1 val=20]FLY UP[/rainbow]", "LEERTASTE ZUM [rainbow freq=0.5 sat=1 val=20]HOCHFLIEGEN[/rainbow]"
-"ACHIEVEMENT_TEN_SHOTS","IT'S RAINING COINS! YOU SHOT 10 TIMES!","ES REGNET MÜNZEN! DU HAST 10 MAL GESCHOSSEN!"
+"CREDITS","CREDITS"
+"
+[wave amp=50 freq=2]HEARTS:[rainbow freq=0.5 sat=1 val=20]%s[/rainbow] [/wave]","
+[wave amp=50 freq=2]HERZEN:[rainbow freq=0.5 sat=1 val=20]%s[/rainbow] [/wave]"
+"
+[wave amp=50 freq=2]LEVEL:[rainbow freq=0.5 sat=1 val=20]%d[/rainbow] [/wave]","
+[wave amp=50 freq=2]LEVEL:[rainbow freq=0.5 sat=1 val=20]%d[/rainbow] [/wave]"
+"
+[wave amp=50 freq=2][rainbow freq=0.5 sat=1 val=20]YOU DIED[/rainbow] [/wave]","
+[wave amp=50 freq=2][rainbow freq=0.5 sat=1 val=20]YOU DIED[/rainbow] [/wave]"
+"[wave amp=50 freq=2]YOU GOT THE STAR:
+[rainbow freq=0.5 sat=1 val=20]%s[/rainbow] [/wave]","[wave amp=50 freq=2]DU HAST DEN STERN:
+[rainbow freq=0.5 sat=1 val=20]%s[/rainbow] [/wave]"
+"
+[wave amp=50 freq=2]YOU ALREADY HAVE:
+[rainbow freq=0.5 sat=1 val=20]%s[/rainbow] [/wave]","
+[wave amp=50 freq=2]DU HAST SCHON:
+[rainbow freq=0.5 sat=1 val=20]%s[/rainbow] [/wave]"
+"ACHIEVEMENT UNLOCKED: %s","ERRUNGENSCHAFT FREIGESCHALTET: %s"
+"GET ALL THE COINS IN LEVEL 0","SAMMLE ALLE MUENZEN IN LEVEL 0"
+"GET ALL THE COINS IN LEVEL 1","SAMMLE ALLE MUENZEN IN LEVEL 1"
+"GET ALL THE COINS IN LEVEL 2","SAMMLE ALLE MUENZEN IN LEVEL 2"
+ "SPACE TO [rainbow freq=0.5 sat=1 val=20]FLY UP[/rainbow]", "LEERTASTE ZUM [rainbow freq=0.5 sat=1 val=20]HOCHFLIEGEN[/rainbow]"
+"IT'S RAINING COINS! YOU SHOT 10 TIMES!","ES REGNET MÜNZEN! DU HAST 10 MAL GESCHOSSEN!"

--- a/localization/loca.csv.import
+++ b/localization/loca.csv.import
@@ -5,10 +5,10 @@ type="Translation"
 
 [deps]
 
-files=[ "res://localization/loca.en.translation", "res://localization/loca.de.translation" ]
+files=[ "res://localization/loca.de.translation" ]
 
 source_file="res://localization/loca.csv"
-dest_files=[ "res://localization/loca.en.translation", "res://localization/loca.de.translation" ]
+dest_files=[ "res://localization/loca.de.translation" ]
 
 [params]
 

--- a/project.godot
+++ b/project.godot
@@ -431,8 +431,8 @@ marwing_right={
 
 [locale]
 
-translations=PoolStringArray( "res://localization/loca.de.translation", "res://localization/loca.en.translation" )
-locale_filter=[ 1, [ "de", "en" ] ]
+translations=PoolStringArray( "res://localization/loca.de.translation" )
+locale_filter=[ 1, [ "de" ] ]
 
 [physics]
 

--- a/scenes/Credits.tscn
+++ b/scenes/Credits.tscn
@@ -39,7 +39,7 @@ margin_right = 1012.0
 margin_bottom = 625.0
 custom_colors/font_color = Color( 1, 1, 1, 1 )
 custom_fonts/font = SubResource( 2 )
-text = "CREDITS_TITLE"
+text = "CREDITS"
 align = 1
 uppercase = true
 

--- a/scenes/levels/Flappy/UI_flappy.tscn
+++ b/scenes/levels/Flappy/UI_flappy.tscn
@@ -86,4 +86,3 @@ B TO FIREBALL
 (WITH POWERUP)"
 fit_content_height = true
 script = ExtResource( 6 )
-localization_key = "TUTORIAL_MOVEMENT_PLANE"

--- a/scenes/ui/AchievementGet.gd
+++ b/scenes/ui/AchievementGet.gd
@@ -69,7 +69,7 @@ func check_achievements():
 func show_completion_message(achievement: Achievement):
 	append_bbcode(
 		"[rainbow][center]"
-		+ tr("ACHIEVEMENT_UNLOCKED") % tr(achievement.description)
+		+ tr("ACHIEVEMENT UNLOCKED: %s") % tr(achievement.description)
 		+ "[/center][/rainbow]"
 	)
 	clear_text_after_seconds()

--- a/scenes/ui/CoinCount.gd
+++ b/scenes/ui/CoinCount.gd
@@ -13,4 +13,4 @@ func _on_coin_collected(_data):
 
 
 func update_coin_count():
-	bbcode_text = tr("UI_COINS") % inventory.coins
+	bbcode_text = tr("\n[wave amp=50 freq=2]COINS:[rainbow freq=0.5 sat=1 val=20]%d[/rainbow] [/wave]") % inventory.coins

--- a/scenes/ui/HeartCount.gd
+++ b/scenes/ui/HeartCount.gd
@@ -12,6 +12,6 @@ func _on_heart_change(_data: Dictionary) -> void:
 
 func _update_hearts() -> void:
 	bbcode_text = (
-		"\n[wave amp=50 freq=2]HEARTS:[rainbow freq=0.5 sat=1 val=20]%d[/rainbow][/wave]"
+		tr("\n[wave amp=50 freq=2]HEARTS:[rainbow freq=0.5 sat=1 val=20]%s[/rainbow] [/wave]")
 		% inventory.hearts
 	)

--- a/scenes/ui/LevelCount.gd
+++ b/scenes/ui/LevelCount.gd
@@ -12,7 +12,7 @@ func _ready():
 
 func _on_level_started(_data):
 	self.show()
-	bbcode_text = "\n" + (tr("UI_LEVEL") % currentLevel)
+	bbcode_text = "\n" + (tr("[wave amp=50 freq=2]LEVEL:[rainbow freq=0.5 sat=1 val=20]%d[/rainbow] [/wave]") % currentLevel)
 	yield(get_tree().create_timer(VisibleTime), "timeout")
 	self.hide()
 

--- a/scenes/ui/PlayerDied.gd
+++ b/scenes/ui/PlayerDied.gd
@@ -8,6 +8,6 @@ func _ready():
 
 func _on_player_died():
 	self.show()
-	$PlayerDied.bbcode_text = "\n" + tr("PLAYER_DIED")
+	$PlayerDied.bbcode_text = "\n" + tr("[wave amp=50 freq=2][rainbow freq=0.5 sat=1 val=20]YOU DIED[/rainbow] [/wave]")
 	yield(get_tree().create_timer(VisibleTime), "timeout")
 	self.hide()

--- a/scenes/ui/StarNotification.gd
+++ b/scenes/ui/StarNotification.gd
@@ -10,12 +10,13 @@ func _ready():
 
 func _on_star_collected(data: Dictionary):
 	self.show()
-	bbcode_text = "\n" + (tr("STARCOLLECT") % data["name"])
+	bbcode_text = "\n" + (tr("[wave amp=50 freq=2]YOU GOT THE STAR:\n[rainbow freq=0.5 sat=1 val=20]%s[/rainbow] [/wave]") % data["name"])
 	yield(get_tree().create_timer(VisibleTime), "timeout")
 	self.hide()
 
+
 func _on_star_collected_again(data: Dictionary):
 	self.show()
-	bbcode_text = "\n" + (tr("STARCOLLECTAGAIN") % data["name"])
+	bbcode_text = "\n" + (tr("[wave amp=50 freq=2]YOU GOT THE STAR:\n[rainbow freq=0.5 sat=1 val=20]%s[/rainbow] [/wave]AGAIN") % data["name"])
 	yield(get_tree().create_timer(VisibleTime), "timeout")
 	self.hide()

--- a/scenes/ui/UI.tscn
+++ b/scenes/ui/UI.tscn
@@ -56,7 +56,6 @@ B TO FIREBALL
 (WITH POWERUP)"
 fit_content_height = true
 script = ExtResource( 6 )
-localization_key = "TUTORIAL_MOVEMENT"
 
 [node name="LevelCount" type="RichTextLabel" parent="UI"]
 anchor_left = 1.0

--- a/scenes/ui/scripts/TranslatedRichTextLabel.gd
+++ b/scenes/ui/scripts/TranslatedRichTextLabel.gd
@@ -1,6 +1,4 @@
 extends RichTextLabel
 
-export var localization_key = "TRANSLATE_ME"
-
 func _ready():
-	bbcode_text = tr(localization_key)
+	bbcode_text = tr(bbcode_text)


### PR DESCRIPTION
Instead of using caps lock keys and translating them into english and
other languages, the english text is now used as a key, which makes it
possible to add translatable text without touching the localization csv file.

This will make it easier to add text-heavy portions of the game, like
dialogs for example.

Before:

```csv
"keys","en","de"
"WAIT_STOP", "Wait, stop!", "Halt, warte!"
```

```gdscript
print(tr("WAIT_STOP")
```

After:

```csv
"keys","de"
"Wait, stop!", "Halt, warte!"
```

```gdscript
print(tr("Wait, stop!")

print(tr("More text")) # Not included in translation file, but prints correct text.
```