### PR TITLE
Add tab keybinding that shows/hides HUB controls.

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -419,6 +419,11 @@ marwing_right={
 , Object(InputEventJoypadMotion,"resource_local_to_scene":false,"resource_name":"","device":0,"axis":0,"axis_value":1.0,"script":null)
  ]
 }
+show_instructions={
+"deadzone": 0.5,
+"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":16777218,"physical_scancode":0,"unicode":0,"echo":false,"script":null)
+ ]
+}
 
 [layer_names]
 

--- a/scenes/ui/UI.tscn
+++ b/scenes/ui/UI.tscn
@@ -18,6 +18,9 @@
 margin_right = 1024.0
 margin_bottom = 600.0
 theme = ExtResource( 5 )
+__meta__ = {
+"_edit_use_anchors_": false
+}
 
 [node name="RichTextLabel" type="RichTextLabel" parent="UI"]
 anchor_left = 0.03
@@ -42,7 +45,9 @@ CONTROL/Z TO [wave amp=50 freq=2]SHOOT[/wave]
 
 B TO[wave amp=50 freq=2] FIREBALL [/wave]
 
-(WITH POWERUP)"
+(WITH POWERUP)
+
+TAB TO SHOW/HIDE CONTROLS"
 text = "ARROW KEYS TO MOVE
 
 SHIFT TO SPRINT
@@ -53,9 +58,14 @@ CONTROL/Z TO SHOOT
 
 B TO FIREBALL 
 
-(WITH POWERUP)"
+(WITH POWERUP)
+
+TAB TO SHOW/HIDE CONTROLS"
 fit_content_height = true
 script = ExtResource( 6 )
+__meta__ = {
+"_edit_use_anchors_": false
+}
 
 [node name="LevelCount" type="RichTextLabel" parent="UI"]
 anchor_left = 1.0

--- a/scripts/Main.gd
+++ b/scripts/Main.gd
@@ -61,6 +61,11 @@ func _on_build(data) -> void:
 			# If the cell has a block in in, break the block.
 			level.set_cell(target_tile_x, target_tile_y, 0)
 
+func _input(event):
+	if event.is_action_pressed("show_instructions"):
+		$UI/UI/RichTextLabel.visible = true
+	elif event.is_action_released("show_instructions"):
+		$UI/UI/RichTextLabel.visible = false
 
 func _on_endportal_body_entered(body: Node2D, next_level: PackedScene, portal: EndPortal) -> void:
 	# Make sure the player can't trigger this function more than once.


### PR DESCRIPTION
https://github.com/a-little-org-called-mario/a-little-game-called-mario/pull/156#issuecomment-1095402907

There are a lot of controls in the hub right now. Probably too many for a new player to memorize.
This PR makes it so that a player can hold tab in any level to see all controls.