### PR TITLE
less obfuscation between internal names for audio buses

### DIFF
--- a/scenes/ui/PauseMenu.gd
+++ b/scenes/ui/PauseMenu.gd
@@ -348,7 +348,7 @@ func volume_select(delta: int, label: RichTextLabel):
 	set_item_style()
 
 	# emit volume change signal, so that Main.gd can modify buses
-	var bus_names = [ "game", "music", "sfx", "voice" ]
+	var bus_names = [ "Master", "music", "sfx", "voice" ]
 	EventBus.emit_signal(
 		"volume_changed", bus_names[selected - 1]
 	)

--- a/scripts/Audio.gd
+++ b/scripts/Audio.gd
@@ -13,4 +13,4 @@ func _on_volume_change(bus: String):
 		"music": volume = Settings.volume_music
 		"sfx": volume = Settings.volume_sfx
 		"voice": volume = Settings.volume_voice
-	AudioServer.set_bus_volume_db(AudioServer.set_bus_volume_db(bus), linear2db(volume / 10.0))
+	AudioServer.set_bus_volume_db(AudioServer.get_bus_index(bus), linear2db(volume / 10.0))

--- a/scripts/Audio.gd
+++ b/scripts/Audio.gd
@@ -1,27 +1,16 @@
 extends Node
 
-
 func _ready():
 	EventBus.connect("volume_changed", self, "_on_volume_change")
-	for bus in ["game", "music", "sfx", "voice"]:
+	for bus in ["Master", "music", "sfx", "voice"]:
 		_on_volume_change(bus)
 
 
-func _on_volume_change(bus: String) -> void:
-	match str(bus):
-		"game":
-			AudioServer.set_bus_volume_db(
-				AudioServer.get_bus_index("Master"), linear2db(Settings.volume_game / 10.0)
-			)
-		"music":
-			AudioServer.set_bus_volume_db(
-				AudioServer.get_bus_index("music"), linear2db(Settings.volume_music / 10.0)
-			)
-		"sfx":
-			AudioServer.set_bus_volume_db(
-				AudioServer.get_bus_index("sfx"), linear2db(Settings.volume_sfx / 10.0)
-			)
-		"voice":
-			AudioServer.set_bus_volume_db(
-				AudioServer.get_bus_index("voice"), linear2db(Settings.volume_voice / 10.0)
-			)
+func _on_volume_change(bus: String):
+	var volume : int = 0
+	match bus:
+		"Master": volume = Settings.volume_game
+		"music": volume = Settings.volume_music
+		"sfx": volume = Settings.volume_sfx
+		"voice": volume = Settings.volume_voice
+	AudioServer.set_bus_volume_db(AudioServer.set_bus_volume_db(bus), linear2db(volume / 10.0))

--- a/scripts/autoload/Settings.gd
+++ b/scripts/autoload/Settings.gd
@@ -73,10 +73,8 @@ func load_data():
 
 	# emit any relevant signals
 	EventBus.emit_signal("crt_filter_toggle", crt_filter)
-	EventBus.emit_signal("volume_changed", "game")
-	EventBus.emit_signal("volume_changed", "music")
-	EventBus.emit_signal("volume_changed", "sfx")
-	EventBus.emit_signal("volume_changed", "voice")
+	for bus in [ "Master", "music", "sfx", "voice" ]:
+		EventBus.emit_signal("volume_changed", bus);
 
 func set_to_default():
 	if camera_lean == -1: camera_lean = CameraLeanAmount.MAX


### PR DESCRIPTION
in any code relating to volume settings, the "Master" bus was called "game"
this changes all references to "game" to "Master", so that hard-coded names of audio buses can be passed directly in any queries to the AudioServer

just a minor refactor of my old code that's been nagging at me