### PR TITLE
CameraFollow now works when solo-playing scene 🎥 

### DIFF
--- a/scenes/levels/CameraFollow.gd
+++ b/scenes/levels/CameraFollow.gd
@@ -31,7 +31,7 @@ var follow_index: int = 0
 func _ready() -> void:
 	_find_current_camera()
 	# If there is no camera (probably because you are running the scene by itself)
-	# create a camera and make it current. The only bad thing ab  
+	# create a camera and make it current. 
 	if camera_reference == null:
 		camera_reference = Camera2D.new()
 		get_tree().root.call_deferred("add_child",camera_reference)

--- a/scenes/levels/CameraFollow.gd
+++ b/scenes/levels/CameraFollow.gd
@@ -30,6 +30,12 @@ var follow_index: int = 0
 
 func _ready() -> void:
 	_find_current_camera()
+	# If there is no camera (probably because you are running the scene by itself)
+	# create a camera and make it current. The only bad thing ab  
+	if camera_reference == null:
+		camera_reference = Camera2D.new()
+		get_tree().root.call_deferred("add_child",camera_reference)
+		camera_reference.make_current()
 
 func _enter_tree() -> void:
 	EventBus.connect("cameraF_candidate_spawned",self,"_get_follow_candidates")


### PR DESCRIPTION
Before, if you wanted to test your scene you'd have to play the whole thing and go through the portals until you reach the level. This was because cameraFollow wouldn't work if you played the scene by itself. 

Now the script catches when there is no camera to use, and creates one to work with. With this change CameraFollow now works when testing scenes by themselves.