### PR TITLE
Fix crash on start of ballmario level.

### DIFF
--- a/scenes/platformer/characters/Trail.gd
+++ b/scenes/platformer/characters/Trail.gd
@@ -4,7 +4,7 @@ export(int) var trail_length = 5
 var positions = []
 var height = 0.0
 
-onready var player: Player = owner
+onready var player: Node2D = owner
 
 
 func _process(_delta):


### PR DESCRIPTION
When starting the ballmario level, an owner is assigned in `Trail.gd`. The type of the owner was to specific and would crash the gdscript VM in debug mode. Made it a `Node2D` which works given the rest of the code of `Trail.gd`.