### PR TITLE
Fixed C++ error from Debugger in cloud.gd

### DIFF
--- a/scenes/levels/Flappy/env/cloud.gd
+++ b/scenes/levels/Flappy/env/cloud.gd
@@ -8,9 +8,9 @@ func _physics_process(delta: float) -> void:
 		queue_free()
 
 
-func _on_Area2D_body_entered(body):
+func _on_Area2D_body_entered(_body):
 	$EnterAudio.play()
 
 
-func _on_Area2D_body_exited(body):
+func _on_Area2D_body_exited(_body):
 	$ExitAudio.play()


### PR DESCRIPTION
This commit addresses the following error from the Godot Debugger:

The argument 'body' is never used in the function
'_on_Area2D_body_entered'. If this is intended, prefix it with
an underscore: '_body'
  <C++ Error>   UNUSED_ARGUMENT
  <Source>      cloud.gd:11