### PR TITLE
Fetch paginated credits from GitHub API.

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -49,19 +49,9 @@ jobs:
         uses: actions/github-script@v3
         with:
           script: |
-            var fs = require('fs');
-            var response = await github.repos.listContributors({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              per_page: 100
-            });
-            var names = '';
-            for (const contributor of response.data) {
-              if (contributor.type == 'User') {
-                names += contributor.login + '\n';
-              }
-            }
-            fs.writeFileSync('credits.txt', names);
+            const path = require('path');
+            const script = require(path.resolve('.github/workflows/update-credits.js'));
+            await script(github, context)
       - name: export with Godot Engine and release on GitHub
         uses: firebelley/godot-export@v3.0.0
         with:

--- a/.github/workflows/build-pull-request.yml
+++ b/.github/workflows/build-pull-request.yml
@@ -24,19 +24,9 @@ jobs:
         uses: actions/github-script@v3
         with:
           script: |
-            var fs = require('fs');
-            var response = await github.repos.listContributors({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              per_page: 100
-            });
-            var names = '';
-            for (const contributor of response.data) {
-              if (contributor.type == 'User') {
-                names += contributor.login + '\n';
-              }
-            }
-            fs.writeFileSync('credits.txt', names);
+            const path = require('path');
+            const script = require(path.resolve('.github/workflows/update-credits.js'));
+            await script(github, context)
       - name: export with Godot Engine
         uses: firebelley/godot-export@v3.0.0
         with:

--- a/.github/workflows/update-credits.js
+++ b/.github/workflows/update-credits.js
@@ -1,0 +1,24 @@
+module.exports = async (github, context) => {
+  var fs = require('fs');
+
+  var names = '';
+
+  for (let page = 1; ; page += 1) {
+    var response = await github.repos.listContributors({
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      per_page: 100,
+      page: page
+    });
+    if (response.data.length == 0) {
+      break;
+    }
+    for (const contributor of response.data) {
+      if (contributor.type == 'User') {
+        names += contributor.login + '\n';
+      }
+    }
+  }
+
+  fs.writeFileSync('credits.txt', names);
+}


### PR DESCRIPTION
This updates the credits.txt-generating script that runs at build time. In the current setup, only the first 100 contributors are fetched. With this PR, every contributor will be listed in credits.txt.

It also splits the credits script into its own file, instead of duplicating it in each workflow.