### PR TITLE
Fix crash in starting the game caused by duplicate line with typo

### DIFF
--- a/scenes/platformer/characters/Player.tscn
+++ b/scenes/platformer/characters/Player.tscn
@@ -15,7 +15,6 @@
 [ext_resource path="res://shaders/hit_flash.gdshader" type="Shader" id=13]
 [ext_resource path="res://scenes/HeartInventoryHandle.tscn" type="PackedScene" id=14]
 [ext_resource path="res://sprites/powerups/Mario Bus stationary-Sheet-export-export.png" type="Texture" id=15]
-[ext_resource path="res://scripts/BoucyMoustache.gd" type="Script" id=16]
 
 [ext_resource path="res://scripts/BouncyMoustache.gd" type="Script" id=16]
 [ext_resource path="res://scenes/CameraFCandidate.gd" type="Script" id=17]


### PR DESCRIPTION
Hey there all! o /
First time doing a pull request here, I've just deleted a line with a typo that caused the game to not start in Godot Engine. By clicking the "Start Game" the game didn't start giving an error on "BoucyMoustache" file