### PR TITLE
Add P button alternative for Main Menu to Sokoban 

### DIFF
--- a/scenes/sokoban/SokobanLevel.gd
+++ b/scenes/sokoban/SokobanLevel.gd
@@ -60,7 +60,7 @@ func _process(delta):
 		undo()
 	elif Input.is_action_just_pressed("restart"):
 		restart()
-	if Input.is_action_just_pressed("ui_cancel"):
+	if Input.is_action_just_pressed("pause"):
 		close_level()
 
 

--- a/scenes/sokoban/SokobanPlayer.tscn
+++ b/scenes/sokoban/SokobanPlayer.tscn
@@ -48,7 +48,7 @@ script = ExtResource( 3 )
 
 [node name="RandalCloud" type="AnimatedSprite" parent="GassyRandal"]
 frames = SubResource( 6 )
-frame = 1
+frame = 3
 speed_scale = 1.25
 playing = true
 
@@ -56,6 +56,7 @@ playing = true
 modulate = Color( 1, 1, 1, 0.439216 )
 scale = Vector2( 1.25, 1.25 )
 frames = SubResource( 6 )
+frame = 4
 speed_scale = 0.75
 playing = true
 

--- a/scenes/sokoban/levels/01.tscn
+++ b/scenes/sokoban/levels/01.tscn
@@ -51,11 +51,11 @@ bbcode_text = "
 [ARROWS]    MOVE
 [R]         RESTART
 [BACKSPACE] UNDO
-[ESC]       MAIN MENU"
+[ESC/P]     MAIN MENU"
 text = "
 [ARROWS]    MOVE
 [R]         RESTART
 [BACKSPACE] UNDO
-[ESC]       MAIN MENU"
+[ESC/P]     MAIN MENU"
 
 [editable path="Instructions"]


### PR DESCRIPTION
Fixes #437

1. Handle `pause` action (p button)
2. Add `[ESC/P]` to instructions 

![image](https://user-images.githubusercontent.com/23484721/164211822-1b434c94-c25b-40b5-8c7f-aee56ed16a57.png)
