### PR TITLE
Add touch controls for Sokoban

### DIFF
--- a/scenes/sokoban/SokobanTouch.gd
+++ b/scenes/sokoban/SokobanTouch.gd
@@ -1,0 +1,4 @@
+extends Node2D
+
+func _ready():
+	self.show()

--- a/scenes/sokoban/SokobanTouch.tscn
+++ b/scenes/sokoban/SokobanTouch.tscn
@@ -1,0 +1,64 @@
+[gd_scene load_steps=6 format=2]
+
+[ext_resource path="res://sprites/touch_input.png" type="Texture" id=1]
+[ext_resource path="res://scenes/sokoban/SokobanTouch.gd" type="Script" id=2]
+
+[sub_resource type="AtlasTexture" id=1]
+atlas = ExtResource( 1 )
+region = Rect2( 0, 0, 48, 48 )
+
+[sub_resource type="AtlasTexture" id=5]
+atlas = ExtResource( 1 )
+region = Rect2( 192, 0, 48, 48 )
+
+[sub_resource type="AtlasTexture" id=4]
+atlas = ExtResource( 1 )
+region = Rect2( 144, 0, 48, 48 )
+
+[node name="SokobanTouch" type="Node2D"]
+script = ExtResource( 2 )
+
+[node name="Left" type="TouchScreenButton" parent="."]
+position = Vector2( 8, 456 )
+scale = Vector2( 1.5, 1.5 )
+normal = SubResource( 1 )
+action = "ui_left"
+visibility_mode = 1
+
+[node name="Right" type="TouchScreenButton" parent="."]
+position = Vector2( 224, 528 )
+rotation = 3.14159
+scale = Vector2( 1.5, 1.5 )
+normal = SubResource( 1 )
+action = "ui_right"
+visibility_mode = 1
+
+[node name="Up" type="TouchScreenButton" parent="."]
+position = Vector2( 152, 392 )
+rotation = 1.5708
+scale = Vector2( 1.5, 1.5 )
+normal = SubResource( 1 )
+action = "ui_up"
+visibility_mode = 1
+
+[node name="Exit" type="TouchScreenButton" parent="."]
+position = Vector2( 16, 16 )
+scale = Vector2( 1.5, 1.5 )
+normal = SubResource( 5 )
+action = "ui_cancel"
+visibility_mode = 1
+
+[node name="Undo" type="TouchScreenButton" parent="."]
+position = Vector2( 840, 456 )
+scale = Vector2( 1.5, 1.5 )
+normal = SubResource( 4 )
+action = "undo"
+visibility_mode = 1
+
+[node name="Down" type="TouchScreenButton" parent="."]
+position = Vector2( 80, 592 )
+rotation = -1.5708
+scale = Vector2( 1.5, 1.5 )
+normal = SubResource( 1 )
+action = "ui_down"
+visibility_mode = 1

--- a/scenes/sokoban/levels/01.tscn
+++ b/scenes/sokoban/levels/01.tscn
@@ -1,10 +1,11 @@
-[gd_scene load_steps=6 format=2]
+[gd_scene load_steps=7 format=2]
 
 [ext_resource path="res://scenes/sokoban/sokoban_tileset.tres" type="TileSet" id=1]
 [ext_resource path="res://audio/music/gassysokoban.mp3" type="AudioStream" id=2]
 [ext_resource path="res://scenes/sokoban/SokobanLevel.gd" type="Script" id=3]
 [ext_resource path="res://scenes/sokoban/SokobanPlayer.tscn" type="PackedScene" id=4]
 [ext_resource path="res://scenes/PictureFrame.tscn" type="PackedScene" id=5]
+[ext_resource path="res://scenes/sokoban/SokobanTouch.tscn" type="PackedScene" id=6]
 
 [node name="SokobanLevel" type="Node2D"]
 script = ExtResource( 3 )
@@ -57,5 +58,8 @@ text = "
 [R]         RESTART
 [BACKSPACE] UNDO
 [ESC]       MAIN MENU"
+
+[node name="SokobanTouch" parent="." instance=ExtResource( 6 )]
+visible = false
 
 [editable path="Instructions"]


### PR DESCRIPTION
It's not the best looking, but it works
I need someone to redesign the buttons later
For now I just ripped off the existing images from Main UI control

1. top left button (crouch) - return to main menu
2. bottom right button (jump) - undo the action 
3. arrows to move

P.S. Its hidden by default to not overload the level scene in the editor. And shown only on the touch screens

![image](https://user-images.githubusercontent.com/23484721/164285921-7eed6989-aa5c-4f10-90bd-415249d6852b.png)