### PR TITLE
Tutorial Portal now Middle of Hub.

### DIFF
--- a/scenes/levels/Hub.tscn
+++ b/scenes/levels/Hub.tscn
@@ -102,5 +102,8 @@ bbcode_text = "[right]N-Z >"
 text = "N-Z >"
 scroll_active = false
 
+[node name="TutorialPortalPos" type="Position2D" parent="."]
+position = Vector2( 96, 160 )
+
 [editable path="Instructions"]
 [editable path="PictureFrameStar"]

--- a/scripts/levels/Hub.gd
+++ b/scripts/levels/Hub.gd
@@ -4,6 +4,7 @@ extends TileMap
 
 
 const LABEL_POSITION := Vector2(6, 6)
+const TUTORIAL_NAME = "TUTORIAL"
 
 export(String, DIR) var levels_directory: String
 export(PackedScene) var portal_scene: PackedScene
@@ -21,8 +22,21 @@ func _ready() -> void:
 	var label_position: Vector2 = portal_template.get_node("Label").position
 
 	var levels: Dictionary = { }
+	var tut_level: Dictionary = { }
 	for level in _get_all_first_levels_in_dir(levels_directory):
-		levels[_get_dir_name(level).to_upper()] = level
+		if _get_dir_name(level).to_upper() != TUTORIAL_NAME:
+			levels[_get_dir_name(level).to_upper()] = level
+		else:
+			tut_level[TUTORIAL_NAME] = level
+
+	# Add tutorial level middle screen
+	if tut_level.size() > 0:
+		var tutorial_portal_pos : Vector2 = $TutorialPortalPos.position
+		create_portal(tut_level[TUTORIAL_NAME], tutorial_portal_pos)
+		var tutorial_label_pos : Vector2 = Vector2(
+			tutorial_portal_pos.x,
+			tutorial_portal_pos.y + portal_rect.size.y + walls_tilemap.cell_size.y / 2)
+		create_label(TUTORIAL_NAME, tutorial_label_pos)
 
 	var n_levels: int = len(levels)
 	var keys: Array = levels.keys()


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/74299074/164295131-13eeba19-c8a4-4cb7-9c5e-001086bfb891.png)
The tutorial portal is now in the middle of the hub.

I think it's important that new players immediately can see that there is a tutorial.
However I don't know if this should be the way it is implemented.