### PR TITLE
marwing: improve player aiming

### DIFF
--- a/scenes/marwing/Marwing.tscn
+++ b/scenes/marwing/Marwing.tscn
@@ -342,13 +342,13 @@ loop = false
 script = ExtResource( 2 )
 forward_speed = 24.4
 strafe_speed = 7.2
-crosshair_range = Vector2( 8, 5 )
-crosshair_speed = 22.2
+crosshair_range = Vector2( 12.5, 7 )
+crosshair_speed = 26.8
 
 [node name="Camera" type="Camera" parent="."]
-transform = Transform( -1, 0, -8.74228e-08, 0, 1, 0, 8.74228e-08, 0, -1, 0, 0, -7 )
+transform = Transform( -1, 0, -8.74228e-08, 0, 1, 0, 8.74228e-08, 0, -1, 0, 0, -5 )
 current = true
-fov = 60.0
+fov = 80.0
 
 [node name="Mesh" type="MeshInstance" parent="."]
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.1, 0 )
@@ -375,7 +375,7 @@ anims/hurt = SubResource( 3 )
 anims/normal = SubResource( 2 )
 
 [node name="Crosshair" type="Sprite3D" parent="."]
-transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 2.5 )
+transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 4.5 )
 pixel_size = 0.015
 texture = ExtResource( 6 )
 

--- a/scripts/marwing/Marwing.gd
+++ b/scripts/marwing/Marwing.gd
@@ -50,11 +50,7 @@ func _physics_process (dt: float):
 		crosshair.translation.y = crosshair_pos.y;
 
 		if Input.is_action_pressed("marwing_shoot"):
-			# note (jam): this aim direction second parameter is held together by scotch tape and bubblegum
-			#             currently, the projectile direction is a bandaid attempt - ideally, bullets should probably come from
-			#             the center of the crosshair. right now, we're just calculating a basic direction vector between crosshair and ship mesh,
-			#             and then biasing it to fit the entire screen. it's consistent, but it's not accurate
-			shoot(mesh.translation,(crosshair.translation-mesh.translation)*Vector3(1,1,5));
+			shoot(mesh.translation,crosshair.translation-mesh.translation);
 
 ## Calculates how much weight a given input should have on the ship's strafe offset by factoring in strafe speed and input strength.
 #  @input_name        the input to check for


### PR DESCRIPTION
tweaks camera & crosshair settings to improve player's ability to aim

it's still not quite _right_ (i think the direction between the crosshair and the **camera** should have more of a factor in order to prevent the projectiles from going off at as wacky of angles, but maybe i'm n u t s) but it's a step up

though tbh i've been playing a lot of rez infinite recently and who knows, maybe a lock on system would be a better solution
that and a banger ost + synesthetic visuals