### PR TITLE
change rendering backend from gles3 to gles2

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -587,6 +587,7 @@ common/enable_pause_aware_picking=true
 
 [rendering]
 
+quality/driver/driver_name="GLES2"
 2d/snapping/use_gpu_pixel_snap=true
 environment/default_clear_color=Color( 0.258824, 0.929412, 1, 1 )
 environment/default_environment="res://default_env.tres"


### PR DESCRIPTION
i've got an entirely uneducated theory is that the marwing crashes (detailed in #332) are due in some part to certain os / browser implementations of webgl 2.0 - so maybe if the game uses webgl 1.0 instead, we might skirt around that problem?

prompting a web build on this really only to see if marwing will even run on previously affected systems - if it doesn't work, there's no point in merging this pr (though from what i tested, this doesn't break anything currently implemented)