### PR TITLE
create function for handling useragent info

### DIFF
--- a/scenes/title/TitleScreen.gd
+++ b/scenes/title/TitleScreen.gd
@@ -1,4 +1,12 @@
 extends Control
 
 func _ready():
+	check_os_browser()
 	Settings.load_data()
+
+func check_os_browser ():
+	var agent: String = JavaScript.eval("navigator.userAgent")
+	
+	#disable marwing label on mac + chrome
+	if "Mac" in agent and "Chrome" in agent:
+		$VBoxContainer/VBoxContainer/HBoxContainer/MarwingButton.hide()


### PR DESCRIPTION
an alternative solution to #332

this just flat out hides the marwing game mode option if it detects that the game is running on mac + chrome
any other potentially necessary browser / os specific tweaks and tricks can be thrown into `check_os_browser` as well and will be run on game startup