### PR TITLE
Convert CoinEmitter to CPUParticle2D

### DIFF
--- a/scenes/boxes/CoinBox.tscn
+++ b/scenes/boxes/CoinBox.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=7 format=2]
+[gd_scene load_steps=6 format=2]
 
 [ext_resource path="res://scenes/boxes/BaseBox.tscn" type="PackedScene" id=1]
 [ext_resource path="res://scripts/boxes/CoinBox.gd" type="Script" id=2]
@@ -11,29 +11,23 @@ particles_anim_h_frames = 5
 particles_anim_v_frames = 1
 particles_anim_loop = false
 
-[sub_resource type="ParticlesMaterial" id=1]
-flag_disable_z = true
-direction = Vector3( 0, -100, 0 )
-spread = 0.0
-gravity = Vector3( 0, 2400, 0 )
-initial_velocity = 800.0
-orbit_velocity = 0.0
-orbit_velocity_random = 0.0
-scale = 3.0
-anim_speed = 1.0
-
 [node name="CoinBox" instance=ExtResource( 1 )]
 script = ExtResource( 2 )
 
-[node name="CoinEmitter" type="Particles2D" parent="." index="2"]
+[node name="CoinEmitter" type="CPUParticles2D" parent="." index="2"]
 material = SubResource( 2 )
 position = Vector2( 0, -8 )
 emitting = false
 amount = 1
 lifetime = 0.2
 one_shot = true
-process_material = SubResource( 1 )
 texture = ExtResource( 3 )
+direction = Vector2( 0, -100 )
+spread = 0.0
+gravity = Vector2( 0, 2400 )
+initial_velocity = 800.0
+scale_amount = 3.0
+anim_speed = 1.0
 
 [node name="CoinStream" type="AudioStreamPlayer2D" parent="." index="5"]
 stream = ExtResource( 4 )


### PR DESCRIPTION
After #477 Particle2D stopped working, so I convert it to CPUParticles2D

![image](https://user-images.githubusercontent.com/23484721/174155286-afbcdb08-53ae-48f2-953e-42c3d1e2bb78.png)
