### PR TITLE
Changed coin requirements on achievements

### DIFF
--- a/achievements/level/0/coins.tres
+++ b/achievements/level/0/coins.tres
@@ -5,4 +5,4 @@
 [resource]
 script = ExtResource( 1 )
 description = "ACHIEVEMENT_COINS_LEVEL0"
-coinsRequired = 5
+coinsRequired = 8

--- a/achievements/level/1/coins.tres
+++ b/achievements/level/1/coins.tres
@@ -5,4 +5,4 @@
 [resource]
 script = ExtResource( 1 )
 description = "ACHIEVEMENT_COINS_LEVEL1"
-coinsRequired = 2
+coinsRequired = 4

--- a/achievements/level/2/coins.tres
+++ b/achievements/level/2/coins.tres
@@ -5,4 +5,4 @@
 [resource]
 script = ExtResource( 1 )
 description = "ACHIEVEMENT_COINS_LEVEL2"
-coinsRequired = 5
+coinsRequired = 8


### PR DESCRIPTION
Now, the coin requirements are as follows
- Level 0: 8 from 5
- Level 1: 4 from 2 (There's a typo on the commit message of 4bbf3e5a104649be42a3dbb47c344bf9fafa295a)
- Level 0: 8 from 5