### PR TITLE
Fix focus of dialog choices in Story Mode

### DIFF
--- a/scenes/levels/story_mode/dialog/DialogUI.gd
+++ b/scenes/levels/story_mode/dialog/DialogUI.gd
@@ -103,6 +103,7 @@ func _set_dialog(to: Dialog):
 		if not condition:
 			return _set_dialog(null)
 	for button in _choice_container.get_children():
+		_choice_container.remove_child(button)
 		button.queue_free()
 	for choice in _dialog.choices:
 		var button := Button.new()


### PR DESCRIPTION
Fix #540

Button wasn't freed because it had reference in `_choice_container` and old button was focused on next dialog

![image](https://user-images.githubusercontent.com/23484721/180059825-5d6ac65f-5ddf-4795-8c79-d17c8e080b8b.png)