### PR TITLE
add saving / persistence of little mario's notes

### DIFF
--- a/scenes/ui/Notes.tscn
+++ b/scenes/ui/Notes.tscn
@@ -53,105 +53,9 @@ region = Rect2( 32, 32, 32, 32 )
 atlas = ExtResource( 21 )
 region = Rect2( 64, 32, 32, 32 )
 
-[sub_resource type="AtlasTexture" id=39]
-atlas = ExtResource( 19 )
-region = Rect2( 0, 0, 80, 80 )
-
-[sub_resource type="AtlasTexture" id=40]
-atlas = ExtResource( 19 )
-region = Rect2( 80, 0, 80, 80 )
-
-[sub_resource type="AtlasTexture" id=41]
-atlas = ExtResource( 19 )
-region = Rect2( 160, 0, 80, 80 )
-
-[sub_resource type="AtlasTexture" id=42]
-atlas = ExtResource( 19 )
-region = Rect2( 240, 0, 80, 80 )
-
-[sub_resource type="AtlasTexture" id=34]
-atlas = ExtResource( 13 )
-region = Rect2( 0, 48, 64, 48 )
-
-[sub_resource type="AtlasTexture" id=35]
-atlas = ExtResource( 13 )
-region = Rect2( 0, 0, 64, 48 )
-
 [sub_resource type="AtlasTexture" id=49]
 atlas = ExtResource( 20 )
 region = Rect2( 0, 0, 31, 31 )
-
-[sub_resource type="AtlasTexture" id=19]
-atlas = ExtResource( 9 )
-region = Rect2( 0, 0, 40, 40 )
-
-[sub_resource type="AtlasTexture" id=20]
-atlas = ExtResource( 9 )
-region = Rect2( 40, 0, 40, 40 )
-
-[sub_resource type="AtlasTexture" id=21]
-atlas = ExtResource( 9 )
-region = Rect2( 80, 0, 40, 40 )
-
-[sub_resource type="AtlasTexture" id=22]
-atlas = ExtResource( 9 )
-region = Rect2( 120, 0, 40, 40 )
-
-[sub_resource type="AtlasTexture" id=23]
-atlas = ExtResource( 9 )
-region = Rect2( 0, 40, 40, 40 )
-
-[sub_resource type="AtlasTexture" id=24]
-atlas = ExtResource( 9 )
-region = Rect2( 40, 40, 40, 40 )
-
-[sub_resource type="AtlasTexture" id=25]
-atlas = ExtResource( 9 )
-region = Rect2( 80, 40, 40, 40 )
-
-[sub_resource type="AtlasTexture" id=26]
-atlas = ExtResource( 9 )
-region = Rect2( 120, 40, 40, 40 )
-
-[sub_resource type="AtlasTexture" id=27]
-atlas = ExtResource( 9 )
-region = Rect2( 0, 80, 40, 40 )
-
-[sub_resource type="AtlasTexture" id=28]
-atlas = ExtResource( 9 )
-region = Rect2( 40, 80, 40, 40 )
-
-[sub_resource type="AtlasTexture" id=36]
-atlas = ExtResource( 17 )
-region = Rect2( 0, 0, 64, 48 )
-
-[sub_resource type="AtlasTexture" id=37]
-atlas = ExtResource( 17 )
-region = Rect2( 0, 48, 64, 48 )
-
-[sub_resource type="AtlasTexture" id=43]
-atlas = ExtResource( 18 )
-region = Rect2( 0, 32, 32, 32 )
-
-[sub_resource type="AtlasTexture" id=44]
-atlas = ExtResource( 18 )
-region = Rect2( 32, 32, 32, 32 )
-
-[sub_resource type="AtlasTexture" id=45]
-atlas = ExtResource( 18 )
-region = Rect2( 64, 32, 32, 32 )
-
-[sub_resource type="AtlasTexture" id=46]
-atlas = ExtResource( 18 )
-region = Rect2( 96, 32, 32, 32 )
-
-[sub_resource type="AtlasTexture" id=47]
-atlas = ExtResource( 18 )
-region = Rect2( 128, 32, 32, 32 )
-
-[sub_resource type="AtlasTexture" id=48]
-atlas = ExtResource( 18 )
-region = Rect2( 160, 32, 32, 32 )
 
 [sub_resource type="AtlasTexture" id=6]
 atlas = ExtResource( 2 )
@@ -221,6 +125,102 @@ region = Rect2( 48, 0, 16, 16 )
 atlas = ExtResource( 16 )
 region = Rect2( 64, 0, 16, 16 )
 
+[sub_resource type="AtlasTexture" id=39]
+atlas = ExtResource( 19 )
+region = Rect2( 0, 0, 80, 80 )
+
+[sub_resource type="AtlasTexture" id=40]
+atlas = ExtResource( 19 )
+region = Rect2( 80, 0, 80, 80 )
+
+[sub_resource type="AtlasTexture" id=41]
+atlas = ExtResource( 19 )
+region = Rect2( 160, 0, 80, 80 )
+
+[sub_resource type="AtlasTexture" id=42]
+atlas = ExtResource( 19 )
+region = Rect2( 240, 0, 80, 80 )
+
+[sub_resource type="AtlasTexture" id=34]
+atlas = ExtResource( 13 )
+region = Rect2( 0, 48, 64, 48 )
+
+[sub_resource type="AtlasTexture" id=35]
+atlas = ExtResource( 13 )
+region = Rect2( 0, 0, 64, 48 )
+
+[sub_resource type="AtlasTexture" id=19]
+atlas = ExtResource( 9 )
+region = Rect2( 0, 0, 40, 40 )
+
+[sub_resource type="AtlasTexture" id=20]
+atlas = ExtResource( 9 )
+region = Rect2( 40, 0, 40, 40 )
+
+[sub_resource type="AtlasTexture" id=21]
+atlas = ExtResource( 9 )
+region = Rect2( 80, 0, 40, 40 )
+
+[sub_resource type="AtlasTexture" id=22]
+atlas = ExtResource( 9 )
+region = Rect2( 120, 0, 40, 40 )
+
+[sub_resource type="AtlasTexture" id=23]
+atlas = ExtResource( 9 )
+region = Rect2( 0, 40, 40, 40 )
+
+[sub_resource type="AtlasTexture" id=24]
+atlas = ExtResource( 9 )
+region = Rect2( 40, 40, 40, 40 )
+
+[sub_resource type="AtlasTexture" id=25]
+atlas = ExtResource( 9 )
+region = Rect2( 80, 40, 40, 40 )
+
+[sub_resource type="AtlasTexture" id=26]
+atlas = ExtResource( 9 )
+region = Rect2( 120, 40, 40, 40 )
+
+[sub_resource type="AtlasTexture" id=27]
+atlas = ExtResource( 9 )
+region = Rect2( 0, 80, 40, 40 )
+
+[sub_resource type="AtlasTexture" id=28]
+atlas = ExtResource( 9 )
+region = Rect2( 40, 80, 40, 40 )
+
+[sub_resource type="AtlasTexture" id=43]
+atlas = ExtResource( 18 )
+region = Rect2( 0, 32, 32, 32 )
+
+[sub_resource type="AtlasTexture" id=44]
+atlas = ExtResource( 18 )
+region = Rect2( 32, 32, 32, 32 )
+
+[sub_resource type="AtlasTexture" id=45]
+atlas = ExtResource( 18 )
+region = Rect2( 64, 32, 32, 32 )
+
+[sub_resource type="AtlasTexture" id=46]
+atlas = ExtResource( 18 )
+region = Rect2( 96, 32, 32, 32 )
+
+[sub_resource type="AtlasTexture" id=47]
+atlas = ExtResource( 18 )
+region = Rect2( 128, 32, 32, 32 )
+
+[sub_resource type="AtlasTexture" id=48]
+atlas = ExtResource( 18 )
+region = Rect2( 160, 32, 32, 32 )
+
+[sub_resource type="AtlasTexture" id=36]
+atlas = ExtResource( 17 )
+region = Rect2( 0, 0, 64, 48 )
+
+[sub_resource type="AtlasTexture" id=37]
+atlas = ExtResource( 17 )
+region = Rect2( 0, 48, 64, 48 )
+
 [sub_resource type="SpriteFrames" id=2]
 animations = [ {
 "frames": [ SubResource( 29 ), SubResource( 30 ), SubResource( 31 ), SubResource( 32 ) ],
@@ -233,55 +233,15 @@ animations = [ {
 "name": "cario_mart",
 "speed": 8.0
 }, {
-"frames": [ SubResource( 39 ), SubResource( 40 ), SubResource( 41 ), SubResource( 42 ) ],
-"loop": true,
-"name": "mega_lawrence_2",
-"speed": 8.0
-}, {
-"frames": [ SubResource( 34 ), SubResource( 35 ) ],
-"loop": true,
-"name": "ombsti",
-"speed": 3.0
-}, {
 "frames": [ SubResource( 49 ) ],
 "loop": true,
 "name": "axelo",
 "speed": 5.0
 }, {
-"frames": [ SubResource( 19 ), SubResource( 20 ), SubResource( 21 ), SubResource( 22 ), SubResource( 23 ), SubResource( 24 ), SubResource( 25 ), SubResource( 26 ), SubResource( 27 ), SubResource( 28 ) ],
-"loop": true,
-"name": "grapeburst_pie",
-"speed": 10.0
-}, {
-"frames": [ ExtResource( 10 ) ],
-"loop": true,
-"name": "ball_mario",
-"speed": 5.0
-}, {
-"frames": [ SubResource( 36 ), SubResource( 37 ) ],
-"loop": true,
-"name": "echo_ombsti",
-"speed": 2.0
-}, {
-"frames": [ SubResource( 43 ), SubResource( 44 ), SubResource( 45 ), SubResource( 46 ), SubResource( 47 ), SubResource( 48 ) ],
-"loop": true,
-"name": "mega_lawrence",
-"speed": 10.0
-}, {
 "frames": [ SubResource( 6 ), SubResource( 7 ), SubResource( 8 ), SubResource( 9 ), SubResource( 10 ), SubResource( 11 ) ],
 "loop": true,
 "name": "little_mario",
 "speed": 10.0
-}, {
-"frames": [ ExtResource( 12 ) ],
-"loop": true,
-"name": "fire_flower",
-"speed": 5.0
-}, {
-"frames": [ ExtResource( 5 ) ],
-"loop": true,
-"name": "blug",
-"speed": 5.0
 }, {
 "frames": [ SubResource( 13 ), SubResource( 14 ), SubResource( 15 ), SubResource( 16 ), SubResource( 17 ), SubResource( 18 ) ],
 "loop": true,
@@ -297,6 +257,46 @@ animations = [ {
 "loop": true,
 "name": "coin",
 "speed": 8.0
+}, {
+"frames": [ SubResource( 39 ), SubResource( 40 ), SubResource( 41 ), SubResource( 42 ) ],
+"loop": true,
+"name": "mega_lawrence_2",
+"speed": 8.0
+}, {
+"frames": [ ExtResource( 5 ) ],
+"loop": true,
+"name": "blug",
+"speed": 5.0
+}, {
+"frames": [ SubResource( 34 ), SubResource( 35 ) ],
+"loop": true,
+"name": "ombsti",
+"speed": 3.0
+}, {
+"frames": [ SubResource( 19 ), SubResource( 20 ), SubResource( 21 ), SubResource( 22 ), SubResource( 23 ), SubResource( 24 ), SubResource( 25 ), SubResource( 26 ), SubResource( 27 ), SubResource( 28 ) ],
+"loop": true,
+"name": "grapeburst_pie",
+"speed": 10.0
+}, {
+"frames": [ ExtResource( 12 ) ],
+"loop": true,
+"name": "fire_flower",
+"speed": 5.0
+}, {
+"frames": [ ExtResource( 10 ) ],
+"loop": true,
+"name": "ball_mario",
+"speed": 5.0
+}, {
+"frames": [ SubResource( 43 ), SubResource( 44 ), SubResource( 45 ), SubResource( 46 ), SubResource( 47 ), SubResource( 48 ) ],
+"loop": true,
+"name": "mega_lawrence",
+"speed": 10.0
+}, {
+"frames": [ SubResource( 36 ), SubResource( 37 ) ],
+"loop": true,
+"name": "echo_ombsti",
+"speed": 2.0
 } ]
 
 [sub_resource type="DynamicFont" id=3]
@@ -400,7 +400,7 @@ position = Vector2( 256, 128 )
 scale = Vector2( 2, 2 )
 frames = SubResource( 2 )
 animation = "cario_mart"
-frame = 2
+frame = 1
 playing = true
 __meta__ = {
 "_editor_description_": "The animation played by this node is the \"Page Sprite\" set using a NotesNewTrigger."

--- a/scripts/ui/Notes.gd
+++ b/scripts/ui/Notes.gd
@@ -3,7 +3,7 @@ extends CanvasLayer
 
 var pages = {}
 
-var notes_file_name = "user://notes.mario"
+const notes_file_name = "user://notes.mario"
 
 export (PackedScene) var noteButton
 
@@ -19,6 +19,7 @@ func _ready():
 	$Hbox.visible = false
 	$Exit.visible = false
 	EventBus.connect("note_added", self, "_on_note_added")
+	remove_pages()
 	load_notes()
 
 
@@ -85,22 +86,20 @@ func load_notes():
 
 	# there is no notes.mario :(
 	if not notes_file.file_exists(notes_file_name) or notes_file.open(notes_file_name, File.READ) != OK:
-		remove_pages() # NOTE (jam): depending on if load_notes gets called anywhere other than _ready,
-					   # this might not be the best way to handle failure
+		return
 	# access notes.mario and read saved notes
-	else:
-		remove_pages()
-		var all_pages = parse_json(notes_file.get_line())
-		for page_name in all_pages.keys():
-			var page = all_pages[page_name]
+	
+	var all_pages = parse_json(notes_file.get_line())
+	for page_name in all_pages.keys():
+		var page = all_pages[page_name]
 
-			# NOTE(jam): godot's json parsing can convert vector2 TO string, but not the other way around
-			var scale_str: String = page.scale
-			scale_str.erase(0, 1)
-			scale_str.erase(scale_str.length() - 1, 1)
-			var scale_arr = scale_str.split(", ")
+		# NOTE(jam): godot's json parsing can convert vector2 TO string, but not the other way around
+		var scale_str: String = page.scale
+		scale_str.erase(0, 1)
+		scale_str.erase(scale_str.length() - 1, 1)
+		var scale_arr = scale_str.split(", ")
 
-			_on_note_added(page_name, page.desc, page.sprite, Vector2(scale_arr[0], scale_arr[1]))
+		_on_note_added(page_name, page.desc, page.sprite, Vector2(scale_arr[0], scale_arr[1]))
 
 func delete_all_notes():
 	pages = {}

--- a/scripts/ui/Notes.gd
+++ b/scripts/ui/Notes.gd
@@ -89,6 +89,7 @@ func load_notes():
 					   # this might not be the best way to handle failure
 	# access notes.mario and read saved notes
 	else:
+		remove_pages()
 		var all_pages = parse_json(notes_file.get_line())
 		for page_name in all_pages.keys():
 			var page = all_pages[page_name]

--- a/scripts/ui/Notes.gd
+++ b/scripts/ui/Notes.gd
@@ -103,6 +103,7 @@ func load_notes():
 			_on_note_added(page_name, page.desc, page.sprite, Vector2(scale_arr[0], scale_arr[1]))
 
 func delete_all_notes():
+	pages = {}
 	remove_pages()
 	save_notes() # NOTE (jam): should be less hassle to overwrite file with an empty json object
 				 # than deleting the cookie and then later recreating the cookie and so on

--- a/scripts/ui/Notes.gd
+++ b/scripts/ui/Notes.gd
@@ -3,6 +3,8 @@ extends CanvasLayer
 
 var pages = {}
 
+var notes_file_name = "user://notes.mario"
+
 export (PackedScene) var noteButton
 
 onready var _list := $Hbox/Scroll/VBox
@@ -17,7 +19,7 @@ func _ready():
 	$Hbox.visible = false
 	$Exit.visible = false
 	EventBus.connect("note_added", self, "_on_note_added")
-	remove_pages()
+	load_notes()
 
 
 func _process(delta):
@@ -45,6 +47,7 @@ func remove_pages():
 
 func add_page(name, desc, sprite, spriteScale):
 	pages[name] = {"desc": desc, "sprite" : sprite, "scale" : spriteScale}
+	save_notes()
 
 
 func add_button(name):
@@ -71,3 +74,34 @@ func _on_page_changed(pageName):
 func _on_Exit_pressed():
 	toggle_visible()
 
+func save_notes():
+	var notes_file = File.new()
+	notes_file.open(notes_file_name, File.WRITE)
+	notes_file.store_line(to_json(pages))
+	notes_file.close()
+
+func load_notes():
+	var notes_file = File.new()
+
+	# there is no notes.mario :(
+	if not notes_file.file_exists(notes_file_name) or notes_file.open(notes_file_name, File.READ) != OK:
+		remove_pages() # NOTE (jam): depending on if load_notes gets called anywhere other than _ready,
+					   # this might not be the best way to handle failure
+	# access notes.mario and read saved notes
+	else:
+		var all_pages = parse_json(notes_file.get_line())
+		for page_name in all_pages.keys():
+			var page = all_pages[page_name]
+
+			# NOTE(jam): godot's json parsing can convert vector2 TO string, but not the other way around
+			var scale_str: String = page.scale
+			scale_str.erase(0, 1)
+			scale_str.erase(scale_str.length() - 1, 1)
+			var scale_arr = scale_str.split(", ")
+
+			_on_note_added(page_name, page.desc, page.sprite, Vector2(scale_arr[0], scale_arr[1]))
+
+func delete_all_notes():
+	remove_pages()
+	save_notes() # NOTE (jam): should be less hassle to overwrite file with an empty json object
+				 # than deleting the cookie and then later recreating the cookie and so on


### PR DESCRIPTION
added three functions:
- `save_notes`: called whenever a new page is added to the list, saves the updated pages object to a user file / cookie called `notes.mario`
- `load_notes`: called in _ready, reads `notes.mario` if it exists and adds each saved page to the list
- `delete_all_notes`: currently unused, but clears the pages object, removes all ui pages / buttons, and overwrites `notes.mario` with an empty object

should address #571