### PR TITLE
bgm_changed signal handler fix

### DIFF
--- a/scripts/Main.gd
+++ b/scripts/Main.gd
@@ -41,6 +41,7 @@ func _bgm_changed(data) -> void:
 			bgm.playing = data.playing
 		if "stream" in data:
 			bgm.stream = data.stream
+			bgm.play()
 
 
 func _hook_portals() -> void:

--- a/scripts/Main.gd
+++ b/scripts/Main.gd
@@ -37,11 +37,12 @@ func _bgm_changed(data) -> void:
 		bgm.stream = defaultBGMStream
 		bgm.playing = true
 	else:
-		if "playing" in data:
-			bgm.playing = data.playing
 		if "stream" in data:
 			bgm.stream = data.stream
-			bgm.play()
+		if "playing" in data:
+			bgm.playing = data.playing
+			if data.playing:
+				bgm.play()
 
 
 func _hook_portals() -> void:


### PR DESCRIPTION
before, the `bgm_changed` event _would_ let you change the AudioStream used by `Main.tscn`'s BGM AudioStreamPlayer, but by default it wouldn't start playing the new music
fine in theory, but this became a pain to deal with when you wanted to change BGM from within a level
now, if the bgm SHOULD play, it actually WILL play