### PR TITLE
luigimansion, visioncone stop at wood tile

### DIFF
--- a/scenes/ConeSpotter.tscn
+++ b/scenes/ConeSpotter.tscn
@@ -13,12 +13,19 @@ visible = false
 self_modulate = Color( 1, 1, 1, 0.368627 )
 polygon = PoolVector2Array( 0, 0, 256, 64, 256, -64 )
 
-[node name="Polygon2D" type="Polygon2D" parent="."]
+[node name="TextureRect" type="TextureRect" parent="."]
+margin_top = -64.0
+margin_right = 256.0
+margin_bottom = 64.0
+rect_clip_content = true
+
+[node name="Polygon2D" type="Polygon2D" parent="TextureRect"]
 self_modulate = Color( 1, 1, 1, 0.12549 )
+position = Vector2( 0, 64 )
 polygon = PoolVector2Array( 0, 0, 256, -64, 256, 64 )
 
 [node name="RayCast2D" type="RayCast2D" parent="."]
 position = Vector2( 4, 0 )
 enabled = true
-cast_to = Vector2( 0, 0 )
-collision_mask = 2
+cast_to = Vector2( 256, 0 )
+collision_mask = 66

--- a/scenes/levels/LuigiMansion/Mansion1.tscn
+++ b/scenes/levels/LuigiMansion/Mansion1.tscn
@@ -927,6 +927,7 @@ rotation = 1.57079
 report_to_group = "squad1"
 cone_width = 64.0
 cone_color = Color( 1, 0, 0, 1 )
+cone_stops_at_tile = true
 
 [node name="AnimationPlayer" type="AnimationPlayer" parent="VisionCone"]
 autoplay = "scroll"


### PR DESCRIPTION
Closes: luigimansion, red detection triangle doesn't stop at blocks #560

### Before:

https://user-images.githubusercontent.com/13420573/182032008-9e911f30-0acb-4c69-9baa-5395c3c9f6ce.mp4

### After:

https://user-images.githubusercontent.com/13420573/182032010-c1a1a12f-6fe5-44ac-82d1-0837456ab794.mp4

### Issue:
The top half of the visioncone is probably too transparent, at least when only the top half is visible.

