### PR TITLE
Fix LuigiMansion boss collision and vision length 

### DIFF
--- a/scenes/levels/LuigiMansion/Mansion2.tscn
+++ b/scenes/levels/LuigiMansion/Mansion2.tscn
@@ -369,6 +369,7 @@ text = "CUTSCENE PLAYING"
 
 [node name="Luigi" parent="." instance=ExtResource( 8 )]
 position = Vector2( 608, 352 )
+collision_mask = 322
 is_mortal = true
 max_health = 20
 fireball_count = 5

--- a/scripts/ConeSpotter.gd
+++ b/scripts/ConeSpotter.gd
@@ -16,6 +16,10 @@ export(NodePath) var tracked_node setget set_tracking
 export(bool) var cone_stops_at_tile: bool = false
 
 
+func _ready():
+	$TextureRect.rect_size.x = cone_length
+
+
 func handle_setup():
 	set_physics_process(false)
 	# Create a triangle using the values set by the exported variables


### PR DESCRIPTION
In #581 size of `TextureRect` set to 256 by default. But in boss battle cone spotter size is different
Also Fix #586: mask `Player Projectile` in `Mega Lawrance` collision

Before:
<img width="90%" height="90%" src="https://user-images.githubusercontent.com/23484721/182041143-ed9f9fbd-6ba1-4eb6-8164-a19413bb48b7.png"/>

After:
<img width="90%" height="90%" src="https://user-images.githubusercontent.com/23484721/182041146-4d87f1e6-6074-40bd-82bb-a996187f6bf7.png"/>
