### PR TITLE
Pipes.tscn, rename root node from center to Pipes

### DIFF
--- a/scenes/levels/Flappy/Characters/Obstacles/Pipes.tscn
+++ b/scenes/levels/Flappy/Characters/Obstacles/Pipes.tscn
@@ -7,7 +7,7 @@
 [sub_resource type="RectangleShape2D" id=1]
 extents = Vector2( 23.75, 159.25 )
 
-[node name="center" type="Node2D"]
+[node name="Pipes" type="Node2D"]
 position = Vector2( 500, 300 )
 script = ExtResource( 2 )
 


### PR DESCRIPTION
The continuously created nodes with the name `center` weren't descriptive, 
on the remote scene tree tab, while playing the flappy game.