### PR TITLE
Flappy, clouds z-index based on scale

### DIFF
--- a/scenes/levels/Flappy/Characters/Obstacles/ObstacleSpawner.gd
+++ b/scenes/levels/Flappy/Characters/Obstacles/ObstacleSpawner.gd
@@ -11,3 +11,4 @@ func _on_Timer_timeout():
 	get_parent().add_child(pipes)
 	pipes.position.x = 1200
 	pipes.position.y = rand_range(240, 360)
+	pipes.z_index = 1

--- a/scenes/levels/Flappy/Flappy01.tscn
+++ b/scenes/levels/Flappy/Flappy01.tscn
@@ -28,6 +28,7 @@ wait_time = 1.5
 
 [node name="Player_RigidBody" parent="." instance=ExtResource( 2 )]
 position = Vector2( 109, 303 )
+z_index = 1
 
 [node name="UI" type="CanvasLayer" parent="."]
 
@@ -120,18 +121,22 @@ script = ExtResource( 1 )
 
 [node name="preset_pipes" parent="." instance=ExtResource( 7 )]
 position = Vector2( 571, 286 )
+z_index = 1
 
 [node name="preset_pipes2" parent="." instance=ExtResource( 7 )]
 position = Vector2( 755, 241 )
+z_index = 1
 
 [node name="preset_pipes3" parent="." instance=ExtResource( 7 )]
 position = Vector2( 954, 296 )
+z_index = 1
 
 [node name="Cloud" parent="." instance=ExtResource( 8 )]
 position = Vector2( 1208, 307 )
 scale = Vector2( 4, 4 )
-region_rect = Rect2( 144, 47, 64, 33.2776 )
+z_index = 2
 SPEED = -120
+player_can_enter_exit_cloud = true
 
 [node name="Cloud2" parent="." instance=ExtResource( 8 )]
 position = Vector2( 863, 63 )
@@ -141,11 +146,20 @@ SPEED = -140
 [node name="Cloud3" parent="." instance=ExtResource( 8 )]
 position = Vector2( 931, 78 )
 scale = Vector2( 3, 3 )
+z_index = 2
+player_can_enter_exit_cloud = true
 
 [node name="Cloud4" parent="." instance=ExtResource( 8 )]
 position = Vector2( 724, 403 )
 scale = Vector2( 2, 2 )
 SPEED = -180
+
+[node name="Cloud5" parent="." instance=ExtResource( 8 )]
+position = Vector2( 504, 473 )
+scale = Vector2( 3, 3 )
+z_index = 2
+SPEED = -170
+player_can_enter_exit_cloud = true
 
 [node name="Cloud6" parent="." instance=ExtResource( 8 )]
 position = Vector2( 1379, 151 )
@@ -154,13 +168,7 @@ SPEED = -240
 
 [node name="Cloud7" parent="." instance=ExtResource( 8 )]
 position = Vector2( 1408, 141 )
-region_rect = Rect2( 1866, -504, 0, 0 )
 SPEED = -150
-
-[node name="Cloud5" parent="." instance=ExtResource( 8 )]
-position = Vector2( 504, 473 )
-scale = Vector2( 3, 3 )
-SPEED = -170
 
 [connection signal="game_over" from="Player_RigidBody" to="." method="_on_Player_game_over"]
 [connection signal="timeout" from="UI/ControlText/HideControlTimer" to="UI/ControlText/ControlTextLabel" method="hide"]

--- a/scenes/levels/Flappy/env/cloud.gd
+++ b/scenes/levels/Flappy/env/cloud.gd
@@ -1,6 +1,7 @@
 extends Sprite
 
 export var SPEED = -200
+export(bool) var player_can_enter_exit_cloud: bool = false
 
 func _physics_process(delta: float) -> void:
 	position.x += SPEED * delta
@@ -9,8 +10,10 @@ func _physics_process(delta: float) -> void:
 
 
 func _on_Area2D_body_entered(_body):
-	$EnterAudio.play()
+	if player_can_enter_exit_cloud:
+		$EnterAudio.play()
 
 
 func _on_Area2D_body_exited(_body):
-	$ExitAudio.play()
+	if player_can_enter_exit_cloud:
+		$ExitAudio.play()

--- a/scenes/levels/Flappy/env/cloud.tscn
+++ b/scenes/levels/Flappy/env/cloud.tscn
@@ -8,10 +8,12 @@
 [node name="Cloud" type="Sprite"]
 texture = ExtResource( 1 )
 region_enabled = true
-region_rect = Rect2( 144, 47, 64, 32 )
+region_rect = Rect2( 144, 47, 64, 33 )
 script = ExtResource( 2 )
 
 [node name="Area2D" type="Area2D" parent="."]
+collision_layer = 512
+collision_mask = 0
 
 [node name="CollisionPolygon2D" type="CollisionPolygon2D" parent="Area2D"]
 position = Vector2( 0, -1 )

--- a/scenes/levels/Flappy/env/env_spawner.gd
+++ b/scenes/levels/Flappy/env/env_spawner.gd
@@ -12,5 +12,10 @@ func _on_env_spawner_timeout():
 	cloud.position.y = rand_range(50, 550)
 	var scale = rand_range(1.0, 4.0)
 	cloud.scale = Vector2(scale, scale)
+	if scale < 2.5:
+		cloud.z_index = 0 # behind player and pipes
+	else:
+		cloud.z_index = 2 # in front of player and pipes
+		cloud.player_can_enter_exit_cloud = true
 	cloud.SPEED = -rand_range(50.0, 220.0)
 	self.wait_time = rand_range(0.2, 4.0)


### PR DESCRIPTION
### Problem:
It's difficult to hit the pipe opening when the player disappears behind the clouds.

And it doesn't look right when the player disappears behind clouds that 
appear behind the pipes, which indicate that they are farther away.

### Fix
Change the cloud's z-index based on their scale (random range, 1.0 to 4.0).
Small clouds (< 2.5) at z-index 0
Player and pipes at z-index 1
Large clouds (>= 2.5) at z-index 2
- ~`partially transparent`~
- plays the player enter/exit sounds

Updated the `Flappy01` scenes initial child nodes based on the rules above:
- `preset_pipes` (3 nodes)
- `Cloud` (7 nodes) 

### Additional changes:
In the scene: `Flappy01` the child node `Cloud7`, wasn't visible,
Fix:
Removed the incorrect region rect: `region_rect = Rect2( 1866, -504, 0, 0 )`
because the `cloud` scene uses: `region_rect = Rect2( 144, 47, 64, 32 )`

The `Cloud` child node's region rect was reset to match the `cloud` scene.
The `cloud` scene's region rect height was extended to show the bottom row of black pixels.

Reordered the `Flappy01` scenes initial clouds based on the node name.

### Before

https://user-images.githubusercontent.com/13420573/182349732-7926cd01-e57a-470c-a44a-0882e4bf141c.mp4

### After

https://user-images.githubusercontent.com/13420573/182349793-6b34526c-9e01-4dd2-9fe4-ad31ac8b0e3d.mp4


