### PR TITLE
Story mode, received item title color

### DIFF
--- a/scenes/ui/Themes/Default/default.tres
+++ b/scenes/ui/Themes/Default/default.tres
@@ -36,3 +36,4 @@ TooltipLabel/colors/font_color = Color( 1, 1, 1, 1 )
 TooltipLabel/colors/font_color_shadow = Color( 0, 0, 0, 1 )
 TooltipLabel/constants/shadow_offset_x = 0
 TooltipLabel/constants/shadow_offset_y = 0
+WindowDialog/colors/title_color = Color( 1, 1, 1, 1 )


### PR DESCRIPTION
In Story Mode, the received item title is difficult to read.

### Before

![before](https://user-images.githubusercontent.com/13420573/182843390-4b14dcfa-1553-4602-8038-0865161da72c.png)

### After

![after](https://user-images.githubusercontent.com/13420573/182843419-3484b68d-990e-4cc1-b7d7-277710f7c249.png)

