### PR TITLE
Fix hit flash reset for Player in new level

### DIFF
--- a/scenes/platformer/characters/Player.gd
+++ b/scenes/platformer/characters/Player.gd
@@ -419,5 +419,5 @@ func flash_sprite() -> void:
 
 
 func _end_flash_sprite() -> void:
-	effect_anim.stop()
+	effect_anim.play("RESET")
 	hitbox.set_deferred('monitoring', true)


### PR DESCRIPTION
If Player enter a portal while still flashing - animation get stuck and not reset 

![image](https://user-images.githubusercontent.com/23484721/183488103-0f3b988a-dc9e-4ae2-8008-1dbb07a0a837.png) ![image](https://user-images.githubusercontent.com/23484721/183488967-40a9e804-7436-48e7-91ea-ee9d6209caf2.png)

