### PR TITLE
Fix music stuttering during scene/level transitions

### DIFF
--- a/scripts/Audio.gd
+++ b/scripts/Audio.gd
@@ -1,11 +1,39 @@
 extends Node
 
+# Playback action that can be executed on an audio player
+enum PlaybackAction {
+	PLAY,
+	STOP,
+	PAUSE,
+	UNPAUSE
+}
 
 func _ready():
+	# Connect to signals
+	EventBus.connect("level_started", self, "_on_level_started")
+	EventBus.connect("level_completed", self, "_on_level_completed")
+	EventBus.connect("change_scene", self, "_on_change_scene")
 	EventBus.connect("volume_changed", self, "_on_volume_change")
+	
+	# Apply initial volume settings
 	for bus in ["Master", "music", "sfx", "voice"]:
 		_on_volume_change(bus)
 
+# Execute a given PlaybackAction on all children of class AudioStreamPlayer
+func _execute_playback_action_on_children(playback_action: int):
+	for child in get_children():
+		if is_instance_valid(child) and child.is_class("AudioStreamPlayer"):
+			match playback_action:
+				PlaybackAction.PLAY:
+					child.play()
+				PlaybackAction.STOP:
+					child.stop()
+				PlaybackAction.PAUSE:
+					child.set_stream_paused(true)
+				PlaybackAction.UNPAUSE:
+					child.set_stream_paused(false)
+
+# ----------------
 
 func _on_volume_change(bus: String):
 	var volume: int = 0
@@ -19,3 +47,12 @@ func _on_volume_change(bus: String):
 		"voice":
 			volume = Settings.volume_voice
 	AudioServer.set_bus_volume_db(AudioServer.get_bus_index(bus), linear2db(volume / 10.0))
+
+func _on_change_scene(data):
+	_execute_playback_action_on_children(PlaybackAction.STOP)
+	
+func _on_level_completed(data):
+	_execute_playback_action_on_children(PlaybackAction.PAUSE)
+
+func _on_level_started(data):
+	_execute_playback_action_on_children(PlaybackAction.UNPAUSE)


### PR DESCRIPTION
This fixes the background music stuttering (#630) by ensuring that the BGM AudioStreamPlayer:
- Stops when changing scenes
- Pauses when completing a level (and resumes when starting a level)

Example video:

https://user-images.githubusercontent.com/2868935/201980120-90d7d80f-19b7-4263-84e0-1233a60306e9.mp4


This does result in a slight pause in the music during level transitions, but should still be preferable to stuttering.