### PR TITLE
Attempt to add credits to artifacts

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -52,6 +52,11 @@ jobs:
             const path = require('path');
             const script = require(path.resolve('.github/workflows/update-credits.js'));
             await script(github, context)
+      - name: Add credits.txt to build artifacts list
+        uses: actions/upload-artifact@v3
+        with:
+          name: credits
+          path: credits.txt
       - name: export with Godot Engine and release on GitHub
         uses: firebelley/godot-export@v3.0.0
         with:


### PR DESCRIPTION
This should have no change other than making it so that GH build actions have the credits.txt file listed as a build artifact at the end of each build.