### PR TITLE
Change title menu option from "OPTIONS" to "SETTINGS" for continuity

### DIFF
--- a/scenes/title/TitleScreen.tscn
+++ b/scenes/title/TitleScreen.tscn
@@ -247,7 +247,7 @@ margin_left = 30.0
 margin_top = 112.0
 margin_right = 148.0
 margin_bottom = 164.0
-text = "OPTIONS"
+text = "SETTINGS"
 redirect_scene = "res://scenes/title/options/OptionsMenu.tscn"
 
 [node name="CreditsButton" parent="VBoxContainer/VBoxContainer" instance=ExtResource( 16 )]


### PR DESCRIPTION
The "SETTINGS" menu is referred to as "OPTIONS" on the title screen, making the game virtually unplayable.

# SETTINGS

<img width="745" height="499" alt="Image 2025-09-19 10-23-21" src="https://github.com/user-attachments/assets/2020b245-55d5-4d01-a384-794d6aebe375" />

<img width="534" height="472" alt="A Little Game Called Mario by isabelle adena kestrel 2025-09-19 10-18-16" src="https://github.com/user-attachments/assets/a7647e15-dab4-4e36-9779-e664ca412adc" />

---

# OPTIONS (deprecated)

<img width="411" height="472" alt="image" src="https://github.com/user-attachments/assets/26b029be-fafb-44c2-9231-37326299f622" />
